### PR TITLE
Fix handling of NaNs in pandas.DataFrame.groupby

### DIFF
--- a/petab/lint.py
+++ b/petab/lint.py
@@ -513,7 +513,8 @@ def measurement_table_has_timepoint_specific_mappings(
          OBSERVABLE_PARAMETERS,
          NOISE_PARAMETERS,
          ])
-    grouped_df = measurement_df.groupby(grouping_cols).size().reset_index()
+    grouped_df = measurement_df.fillna('').groupby(grouping_cols).size()\
+        .reset_index()
 
     grouping_cols = core.get_notnull_columns(
         grouped_df,

--- a/petab/measurements.py
+++ b/petab/measurements.py
@@ -154,10 +154,11 @@ def get_rows_for_condition(measurement_df: pd.DataFrame,
     row_filter = 1
     # check for equality in all grouping cols
     if PREEQUILIBRATION_CONDITION_ID in condition:
-        row_filter = (measurement_df.preequilibrationConditionId ==
+        row_filter = (measurement_df[PREEQUILIBRATION_CONDITION_ID]
+                      .fillna('') ==
                       condition[PREEQUILIBRATION_CONDITION_ID]) & row_filter
     if SIMULATION_CONDITION_ID in condition:
-        row_filter = (measurement_df.simulationConditionId ==
+        row_filter = (measurement_df[SIMULATION_CONDITION_ID] ==
                       condition[SIMULATION_CONDITION_ID]) & row_filter
     # apply filter
     cur_measurement_df = measurement_df.loc[row_filter, :]

--- a/petab/migrations.py
+++ b/petab/migrations.py
@@ -33,7 +33,8 @@ def sbml_observables_to_table(problem: Problem):
     grouping_cols = get_notnull_columns(
         measurement_df, [OBSERVABLE_ID, OBSERVABLE_TRANSFORMATION,
                          NOISE_DISTRIBUTION])
-    grouped = measurement_df.groupby(grouping_cols).count().reset_index()
+    grouped = measurement_df.fillna('').groupby(grouping_cols).count()\
+        .reset_index()
 
     if len(grouped[OBSERVABLE_ID]) != len(grouped[OBSERVABLE_ID]):
         raise ValueError("In order to create an observable table, all "

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -54,7 +54,7 @@ def test_measurement_table_has_timepoint_specific_mappings():
     measurement_df = pd.DataFrame(data={
         OBSERVABLE_ID: ['obs1', 'obs1'],
         SIMULATION_CONDITION_ID: ['condition1', 'condition1'],
-        PREEQUILIBRATION_CONDITION_ID: ['', ''],
+        PREEQUILIBRATION_CONDITION_ID: [nan, nan],
         TIME: [1.0, 2.0],
         OBSERVABLE_PARAMETERS: ['obsParOverride', ''],
         NOISE_PARAMETERS: ['', '']

--- a/tests/test_measurements.py
+++ b/tests/test_measurements.py
@@ -143,3 +143,16 @@ def test_get_simulation_conditions():
                    ignore_index=True)
     actual = petab.get_simulation_conditions(measurement_df)
     assert actual.equals(expected)
+
+    # simulation with and without preequilibration; NaNs
+    measurement_df = pd.DataFrame(data={
+        SIMULATION_CONDITION_ID: ['c0', 'c1', 'c0', 'c1'],
+        PREEQUILIBRATION_CONDITION_ID: [np.nan, np.nan, 'c1', 'c0'],
+    })
+    expected = pd.DataFrame(data={
+        SIMULATION_CONDITION_ID: ['c0', 'c1', 'c0', 'c1'],
+        PREEQUILIBRATION_CONDITION_ID: ['', '', 'c1', 'c0'],
+    }).sort_values([SIMULATION_CONDITION_ID, PREEQUILIBRATION_CONDITION_ID],
+                   ignore_index=True)
+    actual = petab.get_simulation_conditions(measurement_df)
+    assert actual.equals(expected)


### PR DESCRIPTION
Rows with NaNs in grouped-by columns are dropped. This is generally not what we want.