### PR TITLE
Deprecate petab.sbml.globalize_parameters

### DIFF
--- a/petab/sbml.py
+++ b/petab/sbml.py
@@ -131,6 +131,10 @@ def globalize_parameters(sbml_model: libsbml.Model,
             Prepend reaction id of local parameter when
             creating global parameters
     """
+
+    warn("This function will be removed in future releases.",
+         DeprecationWarning)
+
     for reaction in sbml_model.getListOfReactions():
         law = reaction.getKineticLaw()
         # copy first so we can delete in the following loop


### PR DESCRIPTION
Function has nothing to do with PEtab's objectives, and is not usable
at the moment. Better functionality is available through
libsbml.SBMLLocalParameterConverter. Therefore, this should be removed.