### PR TITLE
Release 0.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## 0.1 series
 
+### 0.1.5
+
+Library:
+
+* New create empty observable function (issue 386) (#387)
+* Deprecate petab.sbml.globalize_parameters (#381)
+* Fix computing log10 likelihood (#380)
+* Documentation update and typehints for visualization  (#372)
+* Ordered result of `petab.get_output_parameters`
+* Fix missing argument to parameters.create_parameter_df
+
+Documentation:
+* Add overview of supported PEtab feature in toolboxes
+* Add contribution guide
+* Fix optional values in documentation (#378)
+
+
 ### 0.1.4
 
 Library:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,47 @@
+# PEtab contribution guide
+
+We are happy about contributions to PEtab of any form.
+
+This includes, but is not limited to:
+
+* Extending / improving
+  [documentation and examples](https://petab.readthedocs.io/en/latest/)
+* New library functionality
+* Additional
+  [PEtab application examples](https://github.com/Benchmarking-Initiative/Benchmark-Models-PEtab)
+* Additional minimal
+  [PEtab test cases](https://github.com/PEtab-dev/petab_test_suite)
+
+
+## Extending PEtab
+
+We are aware of the fact that PEtab may not serve everybody's needs. If you
+have a suggestion of how to extend PEtab, feel free to post an
+[issue](https://github.com/PEtab-dev/PEtab/issues) at our GitHub repository.
+
+
+## Contributions to this repository
+
+General:
+
+* For code contributions, please adhere to the
+  [PEP8 style guide](https://www.python.org/dev/peps/pep-0008/)
+* All new functionality should be covered by unit tests
+* Please use Python type hints
+* Please document all modules, functions, classes, attributes, arguments,
+  return values, ... in a style consistent with the rest of the library
+* Use descriptive commit messages
+
+To contribute to this repository:
+
+* Create a pull request
+
+  *By creating a pull request you agree with your contribution being made
+  available under the license terms specified in
+  [https://github.com/PEtab-dev/PEtab/blob/master/LICENSE](https://github.com/PEtab-dev/PEtab/blob/master/LICENSE).*
+
+* Assign a reviewer, or let us know otherwise, that your pull request is ready
+  for review.
+
+* Wait for feedback (and feel free so send a gentle reminder if you did not
+  get any feedback within a week)

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Where PEtab is supported:
   - A PEtab -> [COPASI](http://copasi.org/)
     [converter](https://github.com/copasi/python-petab-importer)
 
-  - [d2d](https://github.com/Data2Dynamics/d2d/) ([HOWTO](https://github.com/Data2Dynamics/d2d/wiki/Support-of-PEtab))
+  - [d2d](https://github.com/Data2Dynamics/d2d/) ([HOWTO](https://github.com/Data2Dynamics/d2d/wiki/Support-for-PEtab))
 
   - [dMod](https://github.com/dkaschek/dMod/)
 
@@ -70,22 +70,22 @@ different tools, based on passed test cases of the
 
 | ID | Test                                                           | AMICI<br>*`develop`* | AMIGO | Copasi | D2D | dMod | pyPESTO<br>*`develop`* | pyABC
 |----|----------------------------------------------------------------|-------|-------|--------|-----|------|-------|------|
-| 1  | Basic simulation                                               | +++   |       |        |     |      | +++   | +++  |
-| 2  | Multiple simulation conditions                                 | +++   |       |        |     |      | +++   | +++  |
-| 3  | Numeric observable parameter overrides in measurement table    | +++   |       |        |     |      | +++   | +++  |
-| 4  | Parametric observable parameter overrides in measurement table | +++   |       |        |     |      | +++   | +++  |
-| 5  | Parametric overrides in condition table                        | +++   |       |        |     |      | +++   | +++  |
-| 6  | Time-point specific overrides in the measurement table         | ---   |       |        |     |      | ---   | ---  |
-| 7  | Observable transformations to log10 scale                      | +-+   |       |        |     |      | +-+   | +-+  |
-| 8  | Replicate measurements                                         | +++   |       |        |     |      | +++   | +++  |
-| 9  | Pre-equilibration                                              | +++   |       |        |     |      | +++   | +++  |
-| 10 | Partial pre-equilibration                                      | +++   |       |        |     |      | +++   | +++  |
-| 11 | Numeric initial concentration in condition table               | +++   |       |        |     |      | +++   | +++  |
-| 12 | Numeric initial compartment sizes in condition table           | ---   |       |        |     |      | ---   | ---  |
-| 13 | Parametric initial concentrations in condition table           | +++   |       |        |     |      | +++   | +++  |
-| 14 | Numeric noise parameter overrides in measurement table         | +++   |       |        |     |      | +++   | +++  |
-| 15 | Parametric noise parameter overrides in measurement table      | +++   |       |        |     |      | +++   | +++  |
-| 16 | Observable transformations to log scale                        | +-+   |       |        |     |      | +-+   | +-+  |
+| 1  | Basic simulation                                               | +++   |       |        | +++ |      | +++   | +++  |
+| 2  | Multiple simulation conditions                                 | +++   |       |        | +++ |      | +++   | +++  |
+| 3  | Numeric observable parameter overrides in measurement table    | +++   |       |        | +++ |      | +++   | +++  |
+| 4  | Parametric observable parameter overrides in measurement table | +++   |       |        | +++ |      | +++   | +++  |
+| 5  | Parametric overrides in condition table                        | +++   |       |        | +++ |      | +++   | +++  |
+| 6  | Time-point specific overrides in the measurement table         | ---   |       |        | +++ |      | ---   | ---  |
+| 7  | Observable transformations to log10 scale                      | +-+   |       |        | +++ |      | +-+   | +-+  |
+| 8  | Replicate measurements                                         | +++   |       |        | +++ |      | +++   | +++  |
+| 9  | Pre-equilibration                                              | +++   |       |        | +++ |      | +++   | +++  |
+| 10 | Partial pre-equilibration                                      | +++   |       |        | +++ |      | +++   | +++  |
+| 11 | Numeric initial concentration in condition table               | +++   |       |        | +++ |      | +++   | +++  |
+| 12 | Numeric initial compartment sizes in condition table           | ---   |       |        | +++ |      | ---   | ---  |
+| 13 | Parametric initial concentrations in condition table           | +++   |       |        | +++ |      | +++   | +++  |
+| 14 | Numeric noise parameter overrides in measurement table         | +++   |       |        | +++ |      | +++   | +++  |
+| 15 | Parametric noise parameter overrides in measurement table      | +++   |       |        | +++ |      | +++   | +++  |
+| 16 | Observable transformations to log scale                        | +-+   |       |        | +++ |      | +-+   | +-+  |
 
     Legend:
     * First character indicates whether computing simulated data is supported and simulations are correct (+) or not (-)

--- a/README.md
+++ b/README.md
@@ -41,26 +41,30 @@ A wide range of PEtab examples can be found in the systems biology parameter est
 
 ## PEtab support in systems biology tools
 
-Where PEtab is supported:
+Where PEtab is supported (in alphabetical order):
 
+
+  - [AMICI](https://github.com/ICB-DCM/AMICI/)
 
   - A PEtab -> [COPASI](http://copasi.org/)
     [converter](https://github.com/copasi/python-petab-importer)
 
-  - [d2d](https://github.com/Data2Dynamics/d2d/) ([HOWTO](https://github.com/Data2Dynamics/d2d/wiki/Support-for-PEtab))
+  - [d2d](https://github.com/Data2Dynamics/d2d/)
+    ([HOWTO](https://github.com/Data2Dynamics/d2d/wiki/Support-for-PEtab))
 
   - [dMod](https://github.com/dkaschek/dMod/)
 
-  - [meigo](http://gingproc.iim.csic.es/meigo.html)
+  - [MEIGO](http://gingproc.iim.csic.es/meigo.html)
 
-  - [AMICI](https://github.com/ICB-DCM/AMICI/)
+  - [parPE](https://github.com/ICB-DCM/parPE/)
 
-  - [pyPESTO](https://github.com/ICB-DCM/pyPESTO/) ([Example](https://pypesto.readthedocs.io/en/latest/example/petab_import.html))
+  - [pyABC](https://github.com/ICB-DCM/pyABC/) ([Example](https://pyabc.readthedocs.io/en/latest/examples/petab.html))
 
-  - [pyABC](https://github.com/ICB-DCM/pyABC/)
+  - [pyPESTO](https://github.com/ICB-DCM/pyPESTO/)
+    ([Example](https://pypesto.readthedocs.io/en/latest/example/petab_import.html))
 
 If your project or tool is using PEtab, and you would like to have it listed
-here, please let us know.
+here, please [let us know](https://github.com/PEtab-dev/PEtab/issues).
 
 ### PEtab features supported in different tools
 
@@ -68,24 +72,24 @@ The following list provides an overview of supported PEtab features in
 different tools, based on passed test cases of the
 [PEtab test suite](https://github.com/PEtab-dev/petab_test_suite):
 
-| ID | Test                                                           | AMICI<br>*`develop`* | AMIGO | Copasi | D2D | dMod | pyPESTO<br>*`develop`* | pyABC
-|----|----------------------------------------------------------------|-------|-------|--------|-----|------|-------|------|
-| 1  | Basic simulation                                               | +++   |       |        | +++ |      | +++   | +++  |
-| 2  | Multiple simulation conditions                                 | +++   |       |        | +++ |      | +++   | +++  |
-| 3  | Numeric observable parameter overrides in measurement table    | +++   |       |        | +++ |      | +++   | +++  |
-| 4  | Parametric observable parameter overrides in measurement table | +++   |       |        | +++ |      | +++   | +++  |
-| 5  | Parametric overrides in condition table                        | +++   |       |        | +++ |      | +++   | +++  |
-| 6  | Time-point specific overrides in the measurement table         | ---   |       |        | +++ |      | ---   | ---  |
-| 7  | Observable transformations to log10 scale                      | +-+   |       |        | +++ |      | +-+   | +-+  |
-| 8  | Replicate measurements                                         | +++   |       |        | +++ |      | +++   | +++  |
-| 9  | Pre-equilibration                                              | +++   |       |        | +++ |      | +++   | +++  |
-| 10 | Partial pre-equilibration                                      | +++   |       |        | +++ |      | +++   | +++  |
-| 11 | Numeric initial concentration in condition table               | +++   |       |        | +++ |      | +++   | +++  |
-| 12 | Numeric initial compartment sizes in condition table           | ---   |       |        | +++ |      | ---   | ---  |
-| 13 | Parametric initial concentrations in condition table           | +++   |       |        | +++ |      | +++   | +++  |
-| 14 | Numeric noise parameter overrides in measurement table         | +++   |       |        | +++ |      | +++   | +++  |
-| 15 | Parametric noise parameter overrides in measurement table      | +++   |       |        | +++ |      | +++   | +++  |
-| 16 | Observable transformations to log scale                        | +-+   |       |        | +++ |      | +-+   | +-+  |
+| ID | Test                                                           | AMICI<br>*`develop`* | Copasi | D2D | dMod | MEIGO | parPE<br>*`develop`*  | pyABC | pyPESTO<br>*`develop`* |
+|----|----------------------------------------------------------------|----------------------|--------|-----|------|-------|-----------------------|-------|------------------------|
+| 1  | Basic simulation                                               | +++                  |        | +++ |      | +++   | --+                   | +++   | +++                    |
+| 2  | Multiple simulation conditions                                 | +++                  |        | +++ |      | +++   | --+                   | +++   | +++                    |
+| 3  | Numeric observable parameter overrides in measurement table    | +++                  |        | +++ |      | +++   | --+                   | +++   | +++                    |
+| 4  | Parametric observable parameter overrides in measurement table | +++                  |        | +++ |      | +++   | --+                   | +++   | +++                    |
+| 5  | Parametric overrides in condition table                        | +++                  |        | +++ |      | +++   | --+                   | +++   | +++                    |
+| 6  | Time-point specific overrides in the measurement table         | ---                  |        | +++ |      | ---   | ---                   | ---   | ---                    |
+| 7  | Observable transformations to log10 scale                      | +-+                  |        | +++ |      | ++-   | --+                   | +-+   | +-+                    |
+| 8  | Replicate measurements                                         | +++                  |        | +++ |      | ---   | --+                   | +++   | +++                    |
+| 9  | Pre-equilibration                                              | +++                  |        | +++ |      | ---   | --+                   | +++   | +++                    |
+| 10 | Partial pre-equilibration                                      | +++                  |        | +++ |      | ---   | --+                   | +++   | +++                    |
+| 11 | Numeric initial concentration in condition table               | +++                  |        | +++ |      | ---   | --+                   | +++   | +++                    |
+| 12 | Numeric initial compartment sizes in condition table           | ---                  |        | +++ |      | ---   | ---                   | ---   | ---                    |
+| 13 | Parametric initial concentrations in condition table           | +++                  |        | +++ |      | ---   | --+                   | +++   | +++                    |
+| 14 | Numeric noise parameter overrides in measurement table         | +++                  |        | +++ |      | +++   | --+                   | +++   | +++                    |
+| 15 | Parametric noise parameter overrides in measurement table      | +++                  |        | +++ |      | +++   | --+                   | +++   | +++                    |
+| 16 | Observable transformations to log scale                        | +-+                  |        | +++ |      | ++-   | --+                   | +-+   | +-+                    |
 
     Legend:
     * First character indicates whether computing simulated data is supported and simulations are correct (+) or not (-)
@@ -124,8 +128,9 @@ further questions regarding PEtab, feel free to post an
 
 ## PEtab Python library
 
-PEtab comes with a Python package for creating, checking, and working with 
-PEtab files. This library is available on pypi and the easiest way to install 
+PEtab comes with a Python package for creating, checking, visualizing and
+working with PEtab files. This library is available on
+[pypi](https://pypi.org/project/petab/) and the easiest way to install
 it is running
 
     pip3 install petab
@@ -152,8 +157,20 @@ be:
   - `petab.create_combine_archive` to create a
     [COMBINE Archive](https://combinearchive.org/index/) from PEtab files
 
-## Extending PEtab
+### Library examples
 
-We are aware of the fact that PEtab may not serve everybody's needs. If you 
-have a suggestion of how to extend PEtab, feel free to post an issue at our 
-github repository.
+Examples for PEtab Python library usage:
+
+* [Validation](https://github.com/PEtab-dev/PEtab/blob/master/doc/example/example_petablint.ipynb)
+* [Visualization](https://github.com/PEtab-dev/PEtab/blob/master/doc/example/example_visualization.ipynb)
+
+
+## Getting help
+
+If you have any question or problems with PEtab, feel free to post them at
+our GitHub [issue tracker](https://github.com/PEtab-dev/PEtab/issues/).
+
+## Contributing to PEtab
+
+Contributions and feedback to PEtab are very welcome, see our
+[contribution guide](CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -33,19 +33,23 @@ for example:
 Documentation of the PEtab data format and Python library is available at
 [https://petab.readthedocs.io/en/latest/](https://petab.readthedocs.io/en/latest/).
 
-## References
+## Examples
 
-Where PEtab is used / supported:
+A wide range of PEtab examples can be found in the systems biology parameter estimation
+[benchmark problem collection](https://github.com/Benchmarking-Initiative/Benchmark-Models-PEtab).
 
-  - Within the systems biology optimization 
-    [benchmark problem collection](https://github.com/Benchmarking-Initiative/Benchmark-Models-PEtab)
+
+## PEtab support in systems biology tools
+
+Where PEtab is supported:
+
 
   - A PEtab -> [COPASI](http://copasi.org/)
     [converter](https://github.com/copasi/python-petab-importer)
 
   - [d2d](https://github.com/Data2Dynamics/d2d/)
 
-  - [dmod](https://github.com/dkaschek/dMod/)
+  - [dMod](https://github.com/dkaschek/dMod/)
 
   - [meigo](http://gingproc.iim.csic.es/meigo.html)
 
@@ -57,6 +61,35 @@ Where PEtab is used / supported:
 
 If your project or tool is using PEtab, and you would like to have it listed
 here, please let us know.
+
+### PEtab features supported in different tools
+
+The following list provides an overview of supported PEtab features in
+different tools, based on passed test cases of the
+[PEtab test suite](https://github.com/PEtab-dev/petab_test_suite):
+
+| ID | Test                                                           | AMICI<br>*`develop`* | AMIGO | Copasi | D2D | dMod | pyPESTO |
+|----|----------------------------------------------------------------|-------|-------|--------|-----|------|------|
+| 1  | Basic simulation                                               | +++   |       |        |     |      |      |
+| 2  | Multiple simulation conditions                                 | +++   |       |        |     |      |      |
+| 3  | Numeric observable parameter overrides in measurement table    | +++   |       |        |     |      |      |
+| 4  | Parametric observable parameter overrides in measurement table | +++   |       |        |     |      |      |
+| 5  | Parametric overrides in condition table                        | +++   |       |        |     |      |      |
+| 6  | Time-point specific overrides in the measurement table         | ---   |       |        |     |      |      |
+| 7  | Observable transformations (lin, log, log10)                   | +-+   |       |        |     |      |      |
+| 8  | Replicate measurements                                         | +++   |       |        |     |      |      |
+| 9  | Pre-equilibration                                              | +++   |       |        |     |      |      |
+| 10 | Partial pre-equilibration                                      | +++   |       |        |     |      |      |
+| 11 | Numeric initial concentration in condition table               | +++   |       |        |     |      |      |
+| 12 | Numeric initial compartment sizes in condition table           | ---   |       |        |     |      |      |
+| 13 | Parametric initial concentrations in condition table           | +++   |       |        |     |      |      |
+| 14 | Numeric noise parameter overrides in measurement table         | +++   |       |        |     |      |      |
+| 15 | Parametric noise parameter overrides in measurement table      | +++   |       |        |     |      |      |
+
+    Legend:
+    * First character indicates whether computing simulated data is supported and simulations are correct (+) or not (-)
+    * Second character indicates whether computing chi2 values of residuals are supported and correct (+) or not (-)
+    * Third character indicates whether computing likelihoods is supported and correct (+) or not (-)
 
 ## Using PEtab
 
@@ -74,6 +107,8 @@ will have to:
   the PEtab documentation
 
 1. Create a condition table, if appropriate
+
+1. Create a table of observables
 
 1. Create a table of measurements
 
@@ -110,10 +145,11 @@ be:
     `petablint`
 
   - `petab.create_parameter_df` to create the parameter table, once you
-    have set up the model, condition table and measurement table
+    have set up the model, condition table, observable table and measurement
+    table
 
-  - Functions in `petab.migrations` for updating PEtab files from earlier
-    versions
+  - `petab.create_combine_archive` to create a
+    [COMBINE Archive](https://combinearchive.org/index/) from PEtab files
 
 ## Extending PEtab
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Where PEtab is supported:
   - A PEtab -> [COPASI](http://copasi.org/)
     [converter](https://github.com/copasi/python-petab-importer)
 
-  - [d2d](https://github.com/Data2Dynamics/d2d/)
+  - [d2d](https://github.com/Data2Dynamics/d2d/) ([HOWTO](https://github.com/Data2Dynamics/d2d/wiki/Support-of-PEtab))
 
   - [dMod](https://github.com/dkaschek/dMod/)
 
@@ -55,7 +55,7 @@ Where PEtab is supported:
 
   - [AMICI](https://github.com/ICB-DCM/AMICI/)
 
-  - [pyPESTO](https://github.com/ICB-DCM/pyPESTO/)
+  - [pyPESTO](https://github.com/ICB-DCM/pyPESTO/) ([Example](https://pypesto.readthedocs.io/en/latest/example/petab_import.html))
 
   - [pyABC](https://github.com/ICB-DCM/pyABC/)
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ different tools, based on passed test cases of the
 | 4  | Parametric observable parameter overrides in measurement table | +++   |       |        |     |      | +++   | +++  |
 | 5  | Parametric overrides in condition table                        | +++   |       |        |     |      | +++   | +++  |
 | 6  | Time-point specific overrides in the measurement table         | ---   |       |        |     |      | ---   | ---  |
-| 7  | Observable transformations (lin, log, log10)                   | +-+   |       |        |     |      | +-+   | +-+  |
+| 7  | Observable transformations to log10 scale                      | +-+   |       |        |     |      | +-+   | +-+  |
 | 8  | Replicate measurements                                         | +++   |       |        |     |      | +++   | +++  |
 | 9  | Pre-equilibration                                              | +++   |       |        |     |      | +++   | +++  |
 | 10 | Partial pre-equilibration                                      | +++   |       |        |     |      | +++   | +++  |
@@ -85,6 +85,7 @@ different tools, based on passed test cases of the
 | 13 | Parametric initial concentrations in condition table           | +++   |       |        |     |      | +++   | +++  |
 | 14 | Numeric noise parameter overrides in measurement table         | +++   |       |        |     |      | +++   | +++  |
 | 15 | Parametric noise parameter overrides in measurement table      | +++   |       |        |     |      | +++   | +++  |
+| 16 | Observable transformations to log scale                        | +-+   |       |        |     |      | +-+   | +-+  |
 
     Legend:
     * First character indicates whether computing simulated data is supported and simulations are correct (+) or not (-)

--- a/README.md
+++ b/README.md
@@ -68,23 +68,23 @@ The following list provides an overview of supported PEtab features in
 different tools, based on passed test cases of the
 [PEtab test suite](https://github.com/PEtab-dev/petab_test_suite):
 
-| ID | Test                                                           | AMICI<br>*`develop`* | AMIGO | Copasi | D2D | dMod | pyPESTO |
-|----|----------------------------------------------------------------|-------|-------|--------|-----|------|------|
-| 1  | Basic simulation                                               | +++   |       |        |     |      |      |
-| 2  | Multiple simulation conditions                                 | +++   |       |        |     |      |      |
-| 3  | Numeric observable parameter overrides in measurement table    | +++   |       |        |     |      |      |
-| 4  | Parametric observable parameter overrides in measurement table | +++   |       |        |     |      |      |
-| 5  | Parametric overrides in condition table                        | +++   |       |        |     |      |      |
-| 6  | Time-point specific overrides in the measurement table         | ---   |       |        |     |      |      |
-| 7  | Observable transformations (lin, log, log10)                   | +-+   |       |        |     |      |      |
-| 8  | Replicate measurements                                         | +++   |       |        |     |      |      |
-| 9  | Pre-equilibration                                              | +++   |       |        |     |      |      |
-| 10 | Partial pre-equilibration                                      | +++   |       |        |     |      |      |
-| 11 | Numeric initial concentration in condition table               | +++   |       |        |     |      |      |
-| 12 | Numeric initial compartment sizes in condition table           | ---   |       |        |     |      |      |
-| 13 | Parametric initial concentrations in condition table           | +++   |       |        |     |      |      |
-| 14 | Numeric noise parameter overrides in measurement table         | +++   |       |        |     |      |      |
-| 15 | Parametric noise parameter overrides in measurement table      | +++   |       |        |     |      |      |
+| ID | Test                                                           | AMICI<br>*`develop`* | AMIGO | Copasi | D2D | dMod | pyPESTO<br>*`develop`* | pyABC
+|----|----------------------------------------------------------------|-------|-------|--------|-----|------|-------|------|
+| 1  | Basic simulation                                               | +++   |       |        |     |      | +++   | +++  |
+| 2  | Multiple simulation conditions                                 | +++   |       |        |     |      | +++   | +++  |
+| 3  | Numeric observable parameter overrides in measurement table    | +++   |       |        |     |      | +++   | +++  |
+| 4  | Parametric observable parameter overrides in measurement table | +++   |       |        |     |      | +++   | +++  |
+| 5  | Parametric overrides in condition table                        | +++   |       |        |     |      | +++   | +++  |
+| 6  | Time-point specific overrides in the measurement table         | ---   |       |        |     |      | ---   | ---  |
+| 7  | Observable transformations (lin, log, log10)                   | +-+   |       |        |     |      | +-+   | +-+  |
+| 8  | Replicate measurements                                         | +++   |       |        |     |      | +++   | +++  |
+| 9  | Pre-equilibration                                              | +++   |       |        |     |      | +++   | +++  |
+| 10 | Partial pre-equilibration                                      | +++   |       |        |     |      | +++   | +++  |
+| 11 | Numeric initial concentration in condition table               | +++   |       |        |     |      | +++   | +++  |
+| 12 | Numeric initial compartment sizes in condition table           | ---   |       |        |     |      | ---   | ---  |
+| 13 | Parametric initial concentrations in condition table           | +++   |       |        |     |      | +++   | +++  |
+| 14 | Numeric noise parameter overrides in measurement table         | +++   |       |        |     |      | +++   | +++  |
+| 15 | Parametric noise parameter overrides in measurement table      | +++   |       |        |     |      | +++   | +++  |
 
     Legend:
     * First character indicates whether computing simulated data is supported and simulations are correct (+) or not (-)

--- a/doc/documentation_data_format.md
+++ b/doc/documentation_data_format.md
@@ -436,7 +436,7 @@ provided) inside the measurement table.
 Expected to have the following columns in any (but preferably this)
 order:
 
-| plotId | [plotName] | plotTypeSimulation | plotTypeData | datasetId | ...
+| plotId | [plotName] | [plotTypeSimulation] | [plotTypeData] | [datasetId] | ...
 |---|---|---|---|---|---|
 | plotId | [plotName] | LinePlot | MeanAndSD | datasetId | ...
 |...|...|...|...|...|...|
@@ -463,62 +463,66 @@ order:
   An ID which corresponds to a specific plot. All datasets with the same
   plotId will be plotted into the same axes object.
 
-- `plotName` [STRING]
+- `plotName` [STRING, OPTIONAL]
 
   A name for the specific plot.
 
-- `plotTypeSimulation` [STRING]
+- `plotTypeSimulation` [STRING, OPTIONAL]
 
   The type of the corresponding plot, can be `LinePlot`, `BarPlot` and `ScatterPlot`. Default
   is `LinePlot`.
 
-- `plotTypeData`
+- `plotTypeData` [STRING, OPTIONAL]
 
   The type how replicates should be handled, can be `MeanAndSD`,
   `MeanAndSEM`, `replicate` (for plotting all replicates separately), or
   `provided` (if numeric values for the noise level are provided in the
   measurement table). Default is `MeanAndSD`.
 
- - `datasetId` [STRING, NOT NULL, REFERENCES(measurementTable.datasetId)]
+- `datasetId` [STRING, NOT NULL, REFERENCES(measurementTable.datasetId), OPTIONAL]
 
   The datasets, which should be grouped into one plot.
 
- - `xValues` [STRING]
+- `xValues` [STRING, OPTIONAL]
 
   The independent variable, which will be plotted on the x-axis. Can be 
   `time` (default, for time resolved data), or it can be `parameterOrStateId`
   for dose-response plots. The corresponding numeric values will be shown on
   the x-axis.
 
- - `xOffset` [NUMERIC]
+- `xOffset` [NUMERIC, OPTIONAL]
 
   Possible data-offsets for the independent variable (default is `0`).
 
- - `xLabel` [STRING]
+- `xLabel` [STRING, OPTIONAL]
 
   Label for the x-axis.
 
-- `xScale` [STRING]
+- `xScale` [STRING, OPTIONAL]
 
   Scale of the independent variable, can be `lin`, `log`, `log10` or `order`.
+  The `order` value should be used if values of the independent variable are
+  ordinal. This value can only be used in combination with `LinePlot` value for
+  the `plotTypeSimulation` column. In this case, points on x axis will be
+  placed equidistantly from each other.
 
-- `yValues` [observableId, REFERENCES(measurementTable.observableId)]
+- `yValues` [observableId, REFERENCES(measurementTable.observableId), OPTIONAL]
 
   The observable which should be plotted on the y-axis.
 
-- `yOffset` [NUMERIC]
+- `yOffset` [NUMERIC, OPTIONAL]
 
   Possible data-offsets for the observable (default is `0`).
 
-- `yLabel` [STRING]
+- `yLabel` [STRING, OPTIONAL]
 
   Label for the y-axis.
 
-- `yScale` [STRING]
+- `yScale` [STRING, OPTIONAL]
 
-  Scale of the observable, can be `lin`, `log`, or `log10`.
+  Scale of the observable, can be `lin`, `log`, or `log10`. Default is `lin`.
 
-- `legendEntry` [STRING]
+- `legendEntry` [STRING, OPTIONAL]
 
   The name that should be displayed for the corresponding dataset in the
   legend and which defaults to `datasetId`.
@@ -528,6 +532,13 @@ order:
 
 Additional columns, such as `Color`, etc. may be specified.
 
+### Examples
+
+Examples of the visualization table can be found in the
+[Benchmark model collection](https://github.com/Benchmarking-Initiative/Benchmark-Models-PEtab/).
+For example, for
+[Chen_MSB2009](https://github.com/Benchmarking-Initiative/Benchmark-Models-PEtab/tree/master/Benchmark-Models/Chen_MSB2009)
+model.
 
 ## YAML file for grouping files
 

--- a/doc/documentation_data_format.md
+++ b/doc/documentation_data_format.md
@@ -1,7 +1,7 @@
 # PEtab data format specification
 
 
-## Version: 1
+## Format version: 1
 
 This document explains the PEtab data format.
 
@@ -46,16 +46,16 @@ components in the core standard, which should provide all information for
 defining the parameter estimation problem.
 
 Extensions of this format (e.g. additional columns in the measurement table)
-are possible and intended. However, those columns should provide extra
+are possible and intended. However, while those columns may provide extra
 information for example for plotting, downstream analysis, or for more
-efficient parameter estimation, but they should not affect the optimization
+efficient parameter estimation, they should not affect the optimization
 problem as such.
 
 **General remarks**
 - All model entities, column names and row names are case-sensitive
 - All identifiers must consist only of upper and lower case letters, digits and
   underscores, and must not start with a digit.
-- Fields in "[]" in the second row are optional and may be left empty.
+- Fields in "[]" are optional and may be left empty.
 
 
 ## SBML model definition
@@ -72,9 +72,11 @@ This is specified as a tab-separated value file in the following way:
 
 | conditionId | [conditionName] | parameterOrSpeciesOrCompartmentId1 | ... | parameterOrSpeciesOrCompartmentId${n} |
 |---|---|---|---|---|
-| conditionId1 | conditionName1 | NUMERIC&#124;parameterId&#124;stateId&#124;compartmentId | ...| ...
-| conditionId2 | ... | ... | ...| ...
-|... | ... | ... | ... |...| ...
+| STRING | [STRING] | NUMERIC&#124;STRING | ... | NUMERIC&#124;STRING |
+| e.g. | | | | |
+| conditionId1 | [conditionName1] | 0.42 | ...| parameterId|
+| conditionId2 | ... | ... | ...| ...|
+|... | ... | ... | ... |...| ...|
 
 Row- and column-ordering are arbitrary, although specifying `conditionId`
 first may improve human readability. 
@@ -127,10 +129,10 @@ model training or validation.
 Expected to have the following named columns in any (but preferably this)
 order:
 
-| observableId | [preequilibrationConditionId] | simulationConditionId | measurement | time |...
-|---|---|---|---|---|---|
-| observableId | [conditionId] | conditionId | NUMERIC | NUMERIC&#124;'inf' |
-|...|...|...|...|...|...|
+| observableId | [preequilibrationConditionId] | simulationConditionId | measurement | time |
+|---|---|---|---|---|
+| observableId | [conditionId] | conditionId | NUMERIC | NUMERIC&#124;inf |
+|...|...|...|...|...|
 
 *(wrapped for readability)*
 
@@ -142,10 +144,10 @@ order:
 Additional (non-standard) columns may be added. If the additional plotting 
 functionality of PEtab should be used, such columns could be
 
-| ... | [datasetId] | [replicateId]  | ... |
-|---|---|---|---|
-|... | [String] | [String] | ... | 
-|...|...|...|...|
+| ... | [datasetId] | [replicateId]  |
+|---|---|---|
+|... | [datasetId] | [replicateId] |
+|...|...|...|
 
 where `datasetId` is a necessary column to use particular plotting 
 functionality, and `replicateId` is optional, which can be used to group 
@@ -162,7 +164,7 @@ replicates and plot error bars.
 REFERENCES(conditionsTable.conditionID), OPTIONAL]
 
   The `conditionId` to be used for preequilibration. E.g. for drug
-  treatments the model would be preequilibrated with the no-drug condition.
+  treatments, the model would be preequilibrated with the no-drug condition.
   Empty for no preequilibration.
 
 - `simulationConditionId` [STRING, NOT NULL,
@@ -241,7 +243,7 @@ The observable table has the following columns:
 
 | observableId | [observableName] | observableFormula | [observableTransformation] | noiseFormula | [noiseDistribution] |
 | --- | --- | --- | --- | --- | --- |
-| [String] | [String] | [String] | ['lin'(default)&#124;'log'&#124;'log10'] |  [String&#124;Number] | ['laplace'&#124;'normal'] |
+| STRING | [STRING] | STRING | [lin(default)&#124;log&#124;log10] |  STRING&#124;NUMBER | [laplace&#124;normal] |
 | e.g. | | | | | | 
 | relativeTotalProtein1 | Relative abundance of Protein1 | observableParameter1 * (protein1 + phospho_protein1 ) | lin | noiseParameter1 | normal |
 | ... |  ... | ... | ... | ... |
@@ -331,7 +333,7 @@ One row per parameter with arbitrary order of rows and columns:
 
 | parameterId | [parameterName] | parameterScale | lowerBound  |upperBound | nominalValue | estimate | [priorType] | [priorParameters] |
 |---|---|---|---|---|---|---|---|---|
-|STRING|STRING|log10&#124;lin&#124;log|NUMERIC|NUMERIC|NUMERIC|0&#124;1|*see below*|*see below*
+|STRING|[STRING]|log10&#124;lin&#124;log|NUMERIC|NUMERIC|NUMERIC|0&#124;1|*see below*|*see below*
 |...|...|...|...|...|...|...|...|...|
 
 Additional columns may be added.
@@ -436,24 +438,24 @@ provided) inside the measurement table.
 Expected to have the following columns in any (but preferably this)
 order:
 
-| plotId | [plotName] | [plotTypeSimulation] | [plotTypeData] | [datasetId] | ...
-|---|---|---|---|---|---|
-| plotId | [plotName] | LinePlot | MeanAndSD | datasetId | ...
-|...|...|...|...|...|...|
+| plotId | [plotName] | [plotTypeSimulation] | [plotTypeData] | [datasetId] |
+|---|---|---|---|---|
+| STRING | [STRING] | [LinePlot(default)&#124;BarPlot&#124;ScatterPlot] | [MeanAndSD(default)&#124;MeanAndSEM&#124;replicate;provided] | datasetId |
+|...|...|...|...|...|
 
 *(wrapped for readability)*
 
-| ... | [xValues] | [xOffset] | [xLabel] | [xScale] | ...
-|---|---|---|---|---|---|
-|... |  [parameterId] | [NUMERIC] | [STRING] | [STRING] | ...
-|...|...|...|...|...|...|
+| ... | [xValues] | [xOffset] | [xLabel] | xScale |
+|---|---|---|---|---|
+|... |  [time(default)&#124;parameterOrStateId] | [NUMERIC] | [STRING] | lin&#124;log&#124;log10&#124;order |
+|...|...|...|...|
 
 *(wrapped for readability)*
 
-| ... | [yValues] | [yOffset] | [yLabel] | [yScale] | [legendEntry] |  ...
-|---|---|---|---|---|---|---|
-|... |  [observableId] | [NUMERIC] | [STRING] | [STRING] | [STRING] | ...
-|...|...|...|...|...|...|...|
+| ... | yValues | [yOffset] | [yLabel] | yScale | [legendEntry] |
+|---|---|---|---|---|---|
+|... |  observableId | [NUMERIC] | [STRING] | lin&#124;log&#124;log10 | [STRING] |
+|...|...|...|...|...|...|
 
 
 ### Detailed field description:
@@ -469,8 +471,7 @@ order:
 
 - `plotTypeSimulation` [STRING, OPTIONAL]
 
-  The type of the corresponding plot, can be `LinePlot`, `BarPlot` and `ScatterPlot`. Default
-  is `LinePlot`.
+  The type of the corresponding plot, can be `LinePlot`, `BarPlot` and `ScatterPlot`. Default is `LinePlot`.
 
 - `plotTypeData` [STRING, OPTIONAL]
 
@@ -481,7 +482,7 @@ order:
 
 - `datasetId` [STRING, NOT NULL, REFERENCES(measurementTable.datasetId), OPTIONAL]
 
-  The datasets, which should be grouped into one plot.
+  The datasets which should be grouped into one plot.
 
 - `xValues` [STRING, OPTIONAL]
 
@@ -496,7 +497,7 @@ order:
 
 - `xLabel` [STRING, OPTIONAL]
 
-  Label for the x-axis.
+  Label for the x-axis. Defaults to the entry in `xValues`.
 
 - `xScale` [STRING, OPTIONAL]
 
@@ -516,7 +517,7 @@ order:
 
 - `yLabel` [STRING, OPTIONAL]
 
-  Label for the y-axis.
+  Label for the y-axis. Defaults to the entry in `yValues`.
 
 - `yScale` [STRING, OPTIONAL]
 
@@ -525,7 +526,7 @@ order:
 - `legendEntry` [STRING, OPTIONAL]
 
   The name that should be displayed for the corresponding dataset in the
-  legend and which defaults to `datasetId`.
+  legend and which defaults to the value in `datasetId`.
 
 
 ### Extensions

--- a/petab/calculate.py
+++ b/petab/calculate.py
@@ -354,13 +354,13 @@ def calculate_single_llh(
     elif noise_distribution == NORMAL and scale == LOG:
         nllh = 0.5*log(2*pi*sigma**2*m**2) + 0.5*((log(s)-log(m))/sigma)**2
     elif noise_distribution == NORMAL and scale == LOG10:
-        nllh = 0.5*log(2*pi*sigma**2*m**2) + \
+        nllh = 0.5*log(2*pi*sigma**2*m**2*log(10)**2) + \
             0.5*((log10(s)-log10(m))/sigma)**2
     elif noise_distribution == LAPLACE and scale == LIN:
         nllh = log(2*sigma) + abs((s-m)/sigma)
     elif noise_distribution == LAPLACE and scale == LOG:
         nllh = log(2*sigma*m) + abs((log(s)-log(m))/sigma)
     elif noise_distribution == LAPLACE and scale == LOG10:
-        nllh = log(2*sigma*m) + abs((log10(s)-log10(m))/sigma)
+        nllh = log(2*sigma*m*log(10)) + abs((log10(s)-log10(m))/sigma)
     llh = - nllh
     return llh

--- a/petab/observables.py
+++ b/petab/observables.py
@@ -150,3 +150,15 @@ def get_placeholders(observable_df: pd.DataFrame) -> List[str]:
                 row[formula_column], row.name, placeholder_type)
             placeholders.extend(cur_placeholders)
     return core.unique_preserve_order(placeholders)
+
+
+def create_observable_df() -> pd.DataFrame:
+    """Create empty observable dataframe
+
+    Returns:
+        Created DataFrame
+    """
+
+    df = pd.DataFrame(data={col: [] for col in OBSERVABLE_DF_COLS})
+
+    return df

--- a/petab/problem.py
+++ b/petab/problem.py
@@ -617,6 +617,7 @@ class Problem:
         return parameters.create_parameter_df(
             self.sbml_model,
             self.condition_df,
+            self.observable_df,
             self.measurement_df,
             *args, **kwargs)
 

--- a/petab/sbml.py
+++ b/petab/sbml.py
@@ -131,6 +131,10 @@ def globalize_parameters(sbml_model: libsbml.Model,
             Prepend reaction id of local parameter when
             creating global parameters
     """
+
+    warn("This function will be removed in future releases.",
+         DeprecationWarning)
+
     for reaction in sbml_model.getListOfReactions():
         law = reaction.getKineticLaw()
         # copy first so we can delete in the following loop

--- a/petab/version.py
+++ b/petab/version.py
@@ -1,2 +1,2 @@
 """PEtab library version"""
-__version__ = '0.1.4'
+__version__ = '0.1.5'

--- a/petab/visualize/helper_functions.py
+++ b/petab/visualize/helper_functions.py
@@ -17,21 +17,27 @@ import seaborn as sns
 from .plotting_config import plot_lowlevel
 from ..C import *
 
-from typing import Union
+from typing import Dict, List, Optional, Tuple, Union
 
 sns.set()
 
+# for typehints
+IdsList = List[str]
+NumList = List[int]
 
-def import_from_files(data_file_path,
-                      condition_file_path,
-                      visualization_file_path,
-                      simulation_file_path,
-                      dataset_id_list,
-                      sim_cond_id_list,
-                      sim_cond_num_list,
-                      observable_id_list,
-                      observable_num_list,
-                      plotted_noise):
+
+def import_from_files(
+        data_file_path: str,
+        condition_file_path: str,
+        visualization_file_path: str,
+        simulation_file_path: str,
+        dataset_id_list: List[IdsList],
+        sim_cond_id_list: List[IdsList],
+        sim_cond_num_list: List[NumList],
+        observable_id_list: List[IdsList],
+        observable_num_list: List[NumList],
+        plotted_noise: str) -> Tuple[pd.DataFrame, pd.DataFrame,
+                                     pd.DataFrame, pd.DataFrame]:
     """
     Helper function for plotting data and simulations, which imports data
     from PEtab files.
@@ -66,12 +72,13 @@ def import_from_files(data_file_path,
     return exp_data, exp_conditions, vis_spec, sim_data
 
 
-def check_vis_spec_consistency(dataset_id_list,
-                               sim_cond_id_list,
-                               sim_cond_num_list,
-                               observable_id_list,
-                               observable_num_list,
-                               exp_data):
+def check_vis_spec_consistency(
+        exp_data: pd.DataFrame,
+        dataset_id_list: Optional[List[IdsList]] = None,
+        sim_cond_id_list: Optional[List[IdsList]] = None,
+        sim_cond_num_list: Optional[List[NumList]] = None,
+        observable_id_list: Optional[List[IdsList]] = None,
+        observable_num_list: Optional[List[NumList]] = None) -> str:
     """
     Helper function for plotting data and simulations, which check the
     visualization setting, if no visualization specification file is provided.
@@ -149,13 +156,14 @@ def check_vis_spec_consistency(dataset_id_list,
     return group_by
 
 
-def create_dataset_id_list(simcond_id_list,
-                           simcond_num_list,
-                           observable_id_list,
-                           observable_num_list,
-                           exp_data,
-                           exp_conditions,
-                           group_by):
+def create_dataset_id_list(
+        simcond_id_list: List[IdsList],
+        simcond_num_list: List[NumList],
+        observable_id_list: List[IdsList],
+        observable_num_list: List[NumList],
+        exp_data: pd.DataFrame,
+        exp_conditions: pd.DataFrame,
+        group_by: str) -> Tuple[pd.DataFrame, List[IdsList], Dict]:
     """Create dataset id list"""
     # create a column of dummy datasetIDs and legend entries: preallocate
     dataset_id_column = []
@@ -239,7 +247,11 @@ def create_dataset_id_list(simcond_id_list,
     return exp_data, dataset_id_list, legend_dict
 
 
-def create_figure(uni_plot_ids: np.ndarray, plots_to_file: bool):
+def create_figure(
+        uni_plot_ids: np.ndarray,
+        plots_to_file: bool) -> Tuple[plt.Figure,
+                                      Union[Dict[str, plt.Subplot],
+                                            'np.ndarray[plt.Subplot]']]:
     """
     Helper function for plotting data and simulations, open figure and axes
 
@@ -287,14 +299,16 @@ def create_figure(uni_plot_ids: np.ndarray, plots_to_file: bool):
     return fig, axes
 
 
-def get_default_vis_specs(exp_data,
-                          exp_conditions,
-                          dataset_id_list=None,
-                          sim_cond_id_list=None,
-                          sim_cond_num_list=None,
-                          observable_id_list=None,
-                          observable_num_list=None,
-                          plotted_noise='MeanAndSD'):
+def get_default_vis_specs(
+        exp_data: pd.DataFrame,
+        exp_conditions: pd.DataFrame,
+        dataset_id_list: Optional[List[IdsList]] = None,
+        sim_cond_id_list: Optional[List[IdsList]] = None,
+        sim_cond_num_list: Optional[List[NumList]] = None,
+        observable_id_list: Optional[List[IdsList]] = None,
+        observable_num_list: Optional[List[NumList]] = None,
+        plotted_noise: Optional[str] = MEAN_AND_SD
+) -> Tuple[pd.DataFrame, pd.DataFrame]:
     """
     Helper function for plotting data and simulations, which creates a
     default visualization table.
@@ -304,8 +318,8 @@ def get_default_vis_specs(exp_data,
 
     # check consistency of settings
     group_by = check_vis_spec_consistency(
-        dataset_id_list, sim_cond_id_list, sim_cond_num_list,
-        observable_id_list, observable_num_list, exp_data)
+        exp_data, dataset_id_list, sim_cond_id_list, sim_cond_num_list,
+        observable_id_list, observable_num_list)
 
     if group_by != 'dataset':
         # datasetId_list will be created (possibly overwriting previous list
@@ -349,7 +363,9 @@ def get_default_vis_specs(exp_data,
     return vis_spec, exp_data
 
 
-def check_ex_visu_columns(vis_spec, dataset_id_list, legend_dict):
+def check_ex_visu_columns(vis_spec: pd.DataFrame,
+                          dataset_id_list: List[IdsList],
+                          legend_dict: Dict) -> pd.DataFrame:
     """
     Check the columns in Visu_Spec file, if non-mandotory columns does not
     exist, create default columns
@@ -396,13 +412,15 @@ def check_ex_visu_columns(vis_spec, dataset_id_list, legend_dict):
     return vis_spec
 
 
-def check_ex_exp_columns(exp_data,
-                         dataset_id_list,
-                         sim_cond_id_list,
-                         sim_cond_num_list,
-                         observable_id_list,
-                         observable_num_list,
-                         exp_conditions):
+def check_ex_exp_columns(
+        exp_data: pd.DataFrame,
+        dataset_id_list: List[IdsList],
+        sim_cond_id_list: List[IdsList],
+        sim_cond_num_list: List[NumList],
+        observable_id_list: List[IdsList],
+        observable_num_list: List[NumList],
+        exp_conditions: pd.DataFrame
+) -> Tuple[pd.DataFrame, List[IdsList], Dict]:
     """
     Check the columns in measurement file, if non-mandotory columns does not
     exist, create default columns
@@ -445,12 +463,12 @@ def check_ex_exp_columns(exp_data,
             # datasetId_list will be created (possibly overwriting previous
             # list - only in the local variable, not in the tsv-file)
             # check consistency of settings
-            group_by = check_vis_spec_consistency(dataset_id_list,
+            group_by = check_vis_spec_consistency(exp_data,
+                                                  dataset_id_list,
                                                   sim_cond_id_list,
                                                   sim_cond_num_list,
                                                   observable_id_list,
-                                                  observable_num_list,
-                                                  exp_data)
+                                                  observable_num_list)
             observable_id_list = \
                 [[el] for el in exp_data.observableId.unique()]
 
@@ -565,15 +583,15 @@ def get_data_to_plot(plot_spec: pd.Series,
         plot_spec:
             information about contains defined data format (visualization file)
         m_data:
-            pandas data frame, contains defined data format (measurement file)
+            contains defined data format (measurement file)
         simulation_data:
-            pandas data frame, contains defined data format (simulation file)
+            contains defined data format (simulation file)
         condition_ids:
-            numpy array, containing all unique condition IDs which should be
+            contains all unique condition IDs which should be
             plotted in one figure (can be found in measurementData file,
             column simulationConditionId)
         col_id:
-            str, the name of the column in visualization file, whose entries
+            the name of the column in visualization file, whose entries
             should be unique (depends on condition in column
             independentVariableName)
         simulation_field:
@@ -582,7 +600,7 @@ def get_data_to_plot(plot_spec: pd.Series,
 
     Returns:
         data_to_plot:
-            pandas.DataFrame containing the data which should be plotted
+            contains the data which should be plotted
             (Mean and Std)
     """
 

--- a/petab/visualize/plot_data_and_simulation.py
+++ b/petab/visualize/plot_data_and_simulation.py
@@ -1,7 +1,7 @@
 """Functions for plotting PEtab measurement files and simulation results in
 the same format."""
 
-from typing import Union, Optional, List
+from typing import Dict, Union, Optional, List
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -33,7 +33,9 @@ def plot_data_and_simulation(
         observable_id_list: Optional[List[IdsList]] = None,
         observable_num_list: Optional[List[NumList]] = None,
         plotted_noise: Optional[str] = MEAN_AND_SD,
-        subplot_file_path: str = ''):
+        subplot_file_path: str = ''
+) -> Optional[Union[Dict[str, plt.Subplot],
+                    'np.ndarray[plt.Subplot]']]:
     """
     Main function for plotting data and simulations.
 
@@ -192,14 +194,16 @@ def plot_data_and_simulation(
     return None
 
 
-def plot_petab_problem(petab_problem: problem.Problem,
-                       sim_data: Optional[Union[str, pd.DataFrame]] = None,
-                       dataset_id_list: Optional[List[IdsList]] = None,
-                       sim_cond_id_list: Optional[List[IdsList]] = None,
-                       sim_cond_num_list: Optional[List[NumList]] = None,
-                       observable_id_list: Optional[List[IdsList]] = None,
-                       observable_num_list: Optional[List[NumList]] = None,
-                       plotted_noise: Optional[str] = MEAN_AND_SD,):
+def plot_petab_problem(
+        petab_problem: problem.Problem,
+        sim_data: Optional[Union[str, pd.DataFrame]] = None,
+        dataset_id_list: Optional[List[IdsList]] = None,
+        sim_cond_id_list: Optional[List[IdsList]] = None,
+        sim_cond_num_list: Optional[List[NumList]] = None,
+        observable_id_list: Optional[List[IdsList]] = None,
+        observable_num_list: Optional[List[NumList]] = None,
+        plotted_noise: Optional[str] = MEAN_AND_SD
+) -> Optional[Union[Dict[str, plt.Subplot], 'np.ndarray[plt.Subplot]']]:
     """
     Visualization using petab problem.
     For documentation, see function plot_data_and_simulation()
@@ -217,9 +221,11 @@ def plot_petab_problem(petab_problem: problem.Problem,
                                     plotted_noise)
 
 
-def plot_measurements_by_observable(data_file_path: str,
-                                    condition_file_path: str,
-                                    plotted_noise: str = MEAN_AND_SD):
+def plot_measurements_by_observable(
+        data_file_path: str,
+        condition_file_path: str,
+        plotted_noise: Optional[str] = MEAN_AND_SD
+) -> Optional[Union[Dict[str, plt.Subplot], 'np.ndarray[plt.Subplot]']]:
     """
     plot measurement data grouped by observable ID.
     A simple wrapper around the more complex function plot_data_and_simulation.
@@ -227,11 +233,11 @@ def plot_measurements_by_observable(data_file_path: str,
     Parameters:
     ----------
 
-    data_file_path: str
+    data_file_path:
         file path of measurement data
-    condition_file_path: str
+    condition_file_path:
         file path of condition file
-    plotted_noise: str (optional)
+    plotted_noise:
         String indicating how noise should be visualized:
         ['MeanAndSD' (default), 'MeanAndSEM', 'replicate', 'provided']
 

--- a/petab/visualize/plotting_config.py
+++ b/petab/visualize/plotting_config.py
@@ -1,4 +1,6 @@
 """Plotting config"""
+from typing import List, Optional, Tuple, Union
+
 import numpy as np
 import pandas as pd
 import seaborn as sns
@@ -11,7 +13,7 @@ def plot_lowlevel(plot_spec: pd.Series,
                   ax: 'matplotlib.pyplot.Axes',
                   conditions: pd.Series,
                   ms: pd.DataFrame,
-                  plot_sim: bool):
+                  plot_sim: bool) -> 'matplotlib.pyplot.Axes':
     """
     plotting routine / preparations: set properties of figure and plot
     the data with given specifications (lineplot with errorbars, or barplot)
@@ -24,11 +26,11 @@ def plot_lowlevel(plot_spec: pd.Series,
     ax:
         axes to which to plot
     conditions:
-        pd.Series, Values on x-axis
+        Values on x-axis
     ms:
-        pd.DataFrame,  containing measurement data which should be plotted
+        contains measurement data which should be plotted
     plot_sim:
-        bool, tells whether or not simulated data should be plotted as well
+        tells whether or not simulated data should be plotted as well
     """
 
     # set yScale
@@ -155,7 +157,9 @@ def plot_lowlevel(plot_spec: pd.Series,
     return ax
 
 
-def square_plot_equal_ranges(ax, lim=None):
+def square_plot_equal_ranges(
+        ax: 'matplotlib.pyplot.Axes',
+        lim: Optional[Union[List, Tuple]] = None) -> 'matplotlib.pyplot.Axes':
     """Square plot with equal range for scatter plots"""
 
     ax.axis('square')

--- a/tests/test_calculate.py
+++ b/tests/test_calculate.py
@@ -262,7 +262,7 @@ def test_calculate_single_llh():
     llh = calculate_single_llh(measurement=m, simulation=s, noise_value=sigma,
                                noise_distribution=NORMAL, scale=LOG10)
     expected_llh = - 0.5 * (((log10(s)-log10(m))/sigma)**2 +
-                            log(2*pi*sigma**2*m**2))
+                            log(2*pi*sigma**2*m**2*log(10)**2))
     assert llh == pytest.approx(expected_llh)
 
     llh = calculate_single_llh(measurement=m, simulation=s, noise_value=sigma,
@@ -277,5 +277,5 @@ def test_calculate_single_llh():
 
     llh = calculate_single_llh(measurement=m, simulation=s, noise_value=sigma,
                                noise_distribution=LAPLACE, scale=LOG10)
-    expected_llh = - abs((log10(s)-log10(m))/sigma) - log(2*sigma*m)
+    expected_llh = - abs((log10(s)-log10(m))/sigma) - log(2*sigma*m*log(10))
     assert llh == pytest.approx(expected_llh)

--- a/tests/test_observables.py
+++ b/tests/test_observables.py
@@ -127,6 +127,12 @@ def test_get_formula_placeholders():
     assert petab.get_formula_placeholders(1, 'any', 'observable') == []
 
 
+def test_create_observable_df():
+    """Test observables.create_measurement_df."""
+    df = petab.create_observable_df()
+    assert set(df.columns.values) == set(OBSERVABLE_DF_COLS)
+
+
 def test_get_placeholders():
     """Test get_placeholders"""
     observable_df = pd.DataFrame(data={

--- a/tests/test_observables.py
+++ b/tests/test_observables.py
@@ -83,7 +83,7 @@ def test_get_output_parameters(minimal_sbml_model):
 
     output_parameters = petab.get_output_parameters(observable_df, model)
 
-    assert output_parameters == {'scaling', 'offset'}
+    assert output_parameters == ['offset', 'scaling']
 
 
 def test_get_formula_placeholders():


### PR DESCRIPTION
Library:

* New create empty observable function (issue 386) (#387)
* Deprecate petab.sbml.globalize_parameters (#381)
* Fix computing log10 likelihood (#380)
* Documentation update and typehints for visualization  (#372)
* Ordered result of `petab.get_output_parameters`
* Fix missing argument to parameters.create_parameter_df

Documentation:
* Add overview of supported PEtab feature in toolboxes
* Add contribution guide
* Fix optional values in documentation (#378)
