### PR TITLE
more tests for visualization routine

### DIFF
--- a/petab/visualize/helper_functions.py
+++ b/petab/visualize/helper_functions.py
@@ -59,14 +59,14 @@ def import_from_files(
         vis_spec = petab.get_visualization_df(visualization_file_path)
     else:
         # create them based on simulation conditions
-        vis_spec = get_default_vis_specs(exp_data,
-                                         exp_conditions,
-                                         dataset_id_list,
-                                         sim_cond_id_list,
-                                         sim_cond_num_list,
-                                         observable_id_list,
-                                         observable_num_list,
-                                         plotted_noise)
+        vis_spec, exp_data = get_default_vis_specs(exp_data,
+                                                   exp_conditions,
+                                                   dataset_id_list,
+                                                   sim_cond_id_list,
+                                                   sim_cond_num_list,
+                                                   observable_id_list,
+                                                   observable_num_list,
+                                                   plotted_noise)
 
     # import simulation file, if file was specified
     if simulation_file_path != '':
@@ -103,8 +103,8 @@ def check_vis_spec_consistency(
     # check whether grouping by simulation condition should be done
     if sim_cond_id_list is not None and sim_cond_num_list is not None:
         raise NotImplementedError(
-            "Either specify a list of dataset IDs or a list of dataset "
-            "numbers, but not both. Stopping.")
+            "Either specify a list of simulation condition IDs or a list of "
+            "simulation condition numbers, but not both. Stopping.")
     if sim_cond_id_list is not None or sim_cond_num_list is not None:
         group_by += 'simulation'
 

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -79,9 +79,9 @@ def test_visualization_with_vis(data_file_Isensee,
                              vis_spec_file_Isensee)
 
 
-def test_visualization_minimal_visu_file(data_file_Fujita,
-                                         condition_file_Fujita,
-                                         visu_file_Fujita_minimal):
+def test_visualization_minimal_visu_file_w_datasetid(data_file_Fujita,
+                                                     condition_file_Fujita,
+                                                     visu_file_Fujita_minimal):
     """
     Test: visualization spezification file only with mandatory columns
     (optional columns are optional)

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -79,38 +79,33 @@ def test_visualization_with_vis(data_file_Isensee,
                              vis_spec_file_Isensee)
 
 
-@pytest.mark.xfail(raises=ValueError)
 def test_visualization_minimal_visu_file(data_file_Fujita,
                                          condition_file_Fujita,
-                                         visu_file_Fujita_minimal,
-                                         simu_file_Fujita):
+                                         visu_file_Fujita_minimal):
     """
     Test: visualization spezification file only with mandatory columns
     (optional columns are optional)
     """
     plot_data_and_simulation(data_file_Fujita,
                              condition_file_Fujita,
-                             visu_file_Fujita_minimal,
-                             simu_file_Fujita)
+                             visu_file_Fujita_minimal)
 
 
-@pytest.mark.xfail(raises=ValueError)
 def test_visualization_minimal_data_file(data_file_Fujita_minimal,
                                          condition_file_Fujita,
-                                         visu_file_Fujita_minimal,
-                                         simu_file_Fujita):
+                                         visu_file_Fujita_minimal):
     """
     Test visualization, with the case: data file only with mandatory columns
     (optional columns are optional)
     """
     plot_data_and_simulation(data_file_Fujita_minimal,
                              condition_file_Fujita,
-                             visu_file_Fujita_minimal,
-                             simu_file_Fujita)
+                             visu_file_Fujita_minimal)
 
 
 def test_visualization_with_dataset_list(data_file_Isensee,
-                                         condition_file_Isensee):
+                                         condition_file_Isensee,
+                                         simulation_file_Isensee):
     datasets = [['JI09_150302_Drg345_343_CycNuc__4_ABnOH_and_ctrl',
                  'JI09_150302_Drg345_343_CycNuc__4_ABnOH_and_Fsk'],
                 ['JI09_160201_Drg453-452_CycNuc__ctrl',
@@ -120,9 +115,15 @@ def test_visualization_with_dataset_list(data_file_Isensee,
                              condition_file_Isensee,
                              dataset_id_list=datasets)
 
+    plot_data_and_simulation(data_file_Isensee,
+                             condition_file_Isensee,
+                             sim_data=simulation_file_Isensee,
+                             dataset_id_list=datasets)
+
 
 def test_visualization_without_datasets(data_file_Fujita,
-                                        condition_file_Fujita):
+                                        condition_file_Fujita,
+                                        simu_file_Fujita):
     sim_cond_num_list = [[0, 1, 2], [0, 2, 3], [0, 3, 4], [0, 4, 5]]
     sim_cond_id_list = [['model1_data1'], ['model1_data2', 'model1_data3'],
                         ['model1_data4', 'model1_data5'], ['model1_data6']]
@@ -133,10 +134,27 @@ def test_visualization_without_datasets(data_file_Fujita,
                              sim_cond_num_list=sim_cond_num_list,
                              plotted_noise=PROVIDED)
     plot_data_and_simulation(data_file_Fujita, condition_file_Fujita,
+                             sim_data=simu_file_Fujita,
+                             sim_cond_num_list=sim_cond_num_list,
+                             plotted_noise=PROVIDED)
+
+    plot_data_and_simulation(data_file_Fujita, condition_file_Fujita,
                              sim_cond_id_list=sim_cond_id_list)
+    plot_data_and_simulation(data_file_Fujita, condition_file_Fujita,
+                             sim_data=simu_file_Fujita,
+                             sim_cond_id_list=sim_cond_id_list)
+
     plot_data_and_simulation(data_file_Fujita, condition_file_Fujita,
                              observable_num_list=observable_num_list)
     plot_data_and_simulation(data_file_Fujita, condition_file_Fujita,
+                             sim_data=simu_file_Fujita,
+                             observable_num_list=observable_num_list)
+
+    plot_data_and_simulation(data_file_Fujita, condition_file_Fujita,
+                             observable_id_list=observable_id_list,
+                             plotted_noise=PROVIDED)
+    plot_data_and_simulation(data_file_Fujita, condition_file_Fujita,
+                             sim_data=simu_file_Fujita,
                              observable_id_list=observable_id_list,
                              plotted_noise=PROVIDED)
 
@@ -164,8 +182,9 @@ def test_visualization_raises(data_file_Fujita,
                                  sim_cond_num_list=sim_cond_num_list,
                                  sim_cond_id_list=sim_cond_id_list)
     except NotImplementedError as ErrMsg:
-        assert(ErrMsg.args[0] == 'Either specify a list of dataset IDs or a '
-                                 'list of dataset numbers, but not both. '
+        assert(ErrMsg.args[0] == 'Either specify a list of simulation '
+                                 'condition IDs or a list of simulation '
+                                 'condition numbers, but not both. '
                                  'Stopping.')
         error_counter += 1
     assert (error_counter == 1)


### PR DESCRIPTION
activate tests for minimal data file (cf issue #415)
tests without visu file now also with simu data

One might still argue that the minimal visualization file is not minimal since it still has the datasetId column. Imo it is only optional if one provide a dataset, condition or observable list to the function plot_data_and_simulation()
Any opinions on this?