### PR TITLE
add sorting of indices of dataframes for the correct sorting of x-values

### DIFF
--- a/petab/visualize/plotting_config.py
+++ b/petab/visualize/plotting_config.py
@@ -97,16 +97,16 @@ def plot_lowlevel(plot_spec: pd.Series,
 
         # construct errorbar-plots: noise specified above
         else:
-            # sort index for the case that indices of conditions and measurements differ
-            # if indep_var='time', conditions is a numpy array,
-            # for indep_var=observable its a Series
+            # sort index for the case that indices of conditions and
+            # measurements differ if indep_var='time', conditions is a numpy
+            # array, for indep_var=observable its a Series
             if isinstance(conditions, np.ndarray):
                 conditions.sort()
             elif isinstance(conditions, pd.core.series.Series):
                 conditions.sort_index(inplace=True)
             else:
-                print('strange: conditions object is neither numpy nor '
-                      'series...')
+                raise ValueError('Strange: conditions object is neither numpy'
+                                 ' nor Series...')
             ms.sort_index(inplace=True)
             # sorts according to ascending order of conditions
             scond, smean, snoise = \

--- a/petab/visualize/plotting_config.py
+++ b/petab/visualize/plotting_config.py
@@ -97,7 +97,7 @@ def plot_lowlevel(plot_spec: pd.Series,
 
         # construct errorbar-plots: noise specified above
         else:
-            # sort index for the case that indices of conditions and ms differ
+            # sort index for the case that indices of conditions and measurements differ
             # if indep_var='time', conditions is a numpy array,
             # for indep_var=observable its a Series
             if isinstance(conditions, np.ndarray):

--- a/petab/visualize/plotting_config.py
+++ b/petab/visualize/plotting_config.py
@@ -106,7 +106,7 @@ def plot_lowlevel(plot_spec: pd.Series,
                 conditions.sort_index(inplace=True)
             else:
                 raise ValueError('Strange: conditions object is neither numpy'
-                                 ' nor Series...')
+                                 ' nor series...')
             ms.sort_index(inplace=True)
             # sorts according to ascending order of conditions
             scond, smean, snoise = \

--- a/petab/visualize/plotting_config.py
+++ b/petab/visualize/plotting_config.py
@@ -98,7 +98,15 @@ def plot_lowlevel(plot_spec: pd.Series,
         # construct errorbar-plots: noise specified above
         else:
             # sort index for the case that indices of conditions and ms differ
-            conditions.sort_index(inplace=True)
+            # if indep_var='time', conditions is a numpy array,
+            # for indep_var=observable its a Series
+            if isinstance(conditions, np.ndarray):
+                conditions.sort()
+            elif isinstance(conditions, pd.core.series.Series):
+                conditions.sort_index(inplace=True)
+            else:
+                print('strange: conditions object is neither numpy nor '
+                      'series...')
             ms.sort_index(inplace=True)
             # sorts according to ascending order of conditions
             scond, smean, snoise = \

--- a/petab/visualize/plotting_config.py
+++ b/petab/visualize/plotting_config.py
@@ -97,6 +97,10 @@ def plot_lowlevel(plot_spec: pd.Series,
 
         # construct errorbar-plots: noise specified above
         else:
+            # sort index for the case that indices of conditions and ms differ
+            conditions.sort_index(inplace=True)
+            ms.sort_index(inplace=True)
+            # sorts according to ascending order of conditions
             scond, smean, snoise = \
                 zip(*sorted(zip(conditions, ms['mean'], ms[noise_col])))
             p = ax.errorbar(


### PR DESCRIPTION
- indices of the dataframes `conditions` and `ms` have to coincide, the problem here was, that they weren't. So now, index sorting is performed before `conditions` and `ms` are zipped together and then afterwards sorted according to ascending conditions. 
closes #414
