### PR TITLE
Make float parsing from CSV round-trip

### DIFF
--- a/petab/conditions.py
+++ b/petab/conditions.py
@@ -23,7 +23,8 @@ def get_condition_df(
         return condition_file
 
     if isinstance(condition_file, str):
-        condition_file = pd.read_csv(condition_file, sep='\t')
+        condition_file = pd.read_csv(condition_file, sep='\t',
+                                     float_precision='round_trip')
 
     lint.assert_no_leading_trailing_whitespace(
         condition_file.columns.values, "condition")

--- a/petab/core.py
+++ b/petab/core.py
@@ -23,7 +23,8 @@ def get_simulation_df(simulation_file: str) -> pd.DataFrame:
     Returns:
         Simulation DataFrame
     """
-    return pd.read_csv(simulation_file, sep="\t", index_col=None)
+    return pd.read_csv(simulation_file, sep="\t", index_col=None,
+                       float_precision='round_trip')
 
 
 def write_simulation_df(df: pd.DataFrame, filename: str) -> None:
@@ -47,7 +48,8 @@ def get_visualization_df(visualization_file: str) -> pd.DataFrame:
         Visualization DataFrame
     """
     try:
-        vis_spec = pd.read_csv(visualization_file, sep="\t", index_col=None)
+        vis_spec = pd.read_csv(visualization_file, sep="\t", index_col=None,
+                               float_precision='round_trip')
     except pd.errors.EmptyDataError:
         warn("Visualization table is empty. Defaults will be used. "
              "Refer to the documentation for details.")

--- a/petab/measurements.py
+++ b/petab/measurements.py
@@ -30,7 +30,8 @@ def get_measurement_df(
         return measurement_file
 
     if isinstance(measurement_file, str):
-        measurement_file = pd.read_csv(measurement_file, sep='\t')
+        measurement_file = pd.read_csv(measurement_file, sep='\t',
+                                       float_precision='round_trip')
 
     lint.assert_no_leading_trailing_whitespace(
         measurement_file.columns.values, MEASUREMENT)

--- a/petab/observables.py
+++ b/petab/observables.py
@@ -28,7 +28,8 @@ def get_observable_df(
         return observable_file
 
     if isinstance(observable_file, str):
-        observable_file = pd.read_csv(observable_file, sep='\t')
+        observable_file = pd.read_csv(observable_file, sep='\t',
+                                      float_precision='round_trip')
 
     lint.assert_no_leading_trailing_whitespace(
         observable_file.columns.values, "observable")

--- a/petab/parameters.py
+++ b/petab/parameters.py
@@ -33,10 +33,12 @@ def get_parameter_df(
         parameter_df = parameter_file
 
     if isinstance(parameter_file, str):
-        parameter_df = pd.read_csv(parameter_file, sep='\t')
+        parameter_df = pd.read_csv(parameter_file, sep='\t',
+                                   float_precision='round_trip')
 
     if isinstance(parameter_file, list):
-        parameter_df = pd.concat([pd.read_csv(subset_file, sep='\t')
+        parameter_df = pd.concat([pd.read_csv(subset_file, sep='\t',
+                                              float_precision='round_trip')
                                   for subset_file in parameter_file])
         # Remove identical parameter definitions
         parameter_df.drop_duplicates(inplace=True, ignore_index=True)


### PR DESCRIPTION
`pandas` uses by default a C parser for CSV files for performance reasons. The default behaviour of such parser when parsing floating point values from strings is different from Python's behaviour. While Python parsing can be round-tripped (e.g., `float(0.999) == 0.999`) this is not true for the C parser.
I believe most users nowadays expect floats to be parsed correctly, so I added a keyword argument to all instances of `pandas.read_csv` asking for the Python-like behaviour. The only downside is that this behaviour is slower (the C code actually calls Python to perform the parsing). This may be more relevant for the parameter table and less important for measurement tables, so it may also be acceptable to enable it only for some tables and not others.