### PR TITLE
Lint: detect duplicated observable IDs

### DIFF
--- a/petab/lint.py
+++ b/petab/lint.py
@@ -133,6 +133,9 @@ def check_measurement_df(df: pd.DataFrame,
         if OBSERVABLE_TRANSFORMATION in observable_df:
             # Check for positivity of measurements in case of
             #  log-transformation
+            assert_observable_id_is_unique(observable_df)
+            # If the above is not checked, in the following loop
+            # trafo may become a pandas Series
             for measurement, obs_id in zip(df[MEASUREMENT], df[OBSERVABLE_ID]):
                 trafo = observable_df.loc[obs_id, OBSERVABLE_TRANSFORMATION]
                 if measurement <= 0.0 and trafo in [LOG, LOG10]:
@@ -238,6 +241,7 @@ def check_observable_df(observable_df: pd.DataFrame) -> None:
                 observable_df[column_name].values, column_name)
 
     assert_noise_distributions_valid(observable_df)
+    assert_observable_id_is_unique(observable_df)
 
     # Check that formulas are parsable
     for row in observable_df.itertuples():
@@ -619,6 +623,21 @@ def assert_noise_distributions_valid(observable_df: pd.DataFrame) -> None:
                 raise ValueError(
                     f"Unrecognized noise distribution in observable "
                     f"table: {distr}.")
+
+
+def assert_observable_id_is_unique(observable_df: pd.DataFrame) -> None:
+    """
+    Check if the observableId column of the observable table is unique.
+
+    Arguments:
+        observable_df: PEtab observable DataFrame
+
+    Raises:
+        AssertionError: in case of problems
+    """
+    if len(observable_df.index) != len(set(observable_df.index)):
+        raise AssertionError(
+            f"{OBSERVABLE_ID} column in observable table is not unique.")
 
 
 def lint_problem(problem: 'petab.Problem') -> bool:

--- a/petab/lint.py
+++ b/petab/lint.py
@@ -5,6 +5,7 @@ import logging
 import numbers
 import re
 from typing import Optional, Iterable
+from collections import Counter
 
 import libsbml
 import numpy as np
@@ -133,7 +134,7 @@ def check_measurement_df(df: pd.DataFrame,
         if OBSERVABLE_TRANSFORMATION in observable_df:
             # Check for positivity of measurements in case of
             #  log-transformation
-            assert_observable_id_is_unique(observable_df)
+            assert_unique_observable_ids(observable_df)
             # If the above is not checked, in the following loop
             # trafo may become a pandas Series
             for measurement, obs_id in zip(df[MEASUREMENT], df[OBSERVABLE_ID]):
@@ -205,7 +206,7 @@ def check_parameter_df(
     assert_parameter_scale_is_valid(df)
     assert_parameter_bounds_are_numeric(df)
     assert_parameter_estimate_is_boolean(df)
-    assert_parameter_id_is_unique(df)
+    assert_unique_parameter_ids(df)
     check_parameter_bounds(df)
     assert_parameter_prior_type_is_valid(df)
 
@@ -241,7 +242,7 @@ def check_observable_df(observable_df: pd.DataFrame) -> None:
                 observable_df[column_name].values, column_name)
 
     assert_noise_distributions_valid(observable_df)
-    assert_observable_id_is_unique(observable_df)
+    assert_unique_observable_ids(observable_df)
 
     # Check that formulas are parsable
     for row in observable_df.itertuples():
@@ -363,7 +364,7 @@ def assert_parameter_id_is_string(parameter_df: pd.DataFrame) -> None:
             raise AssertionError(f"Empty {PARAMETER_ID} found.")
 
 
-def assert_parameter_id_is_unique(parameter_df: pd.DataFrame) -> None:
+def assert_unique_parameter_ids(parameter_df: pd.DataFrame) -> None:
     """
     Check if the parameterId column of the parameter table is unique.
 
@@ -373,9 +374,11 @@ def assert_parameter_id_is_unique(parameter_df: pd.DataFrame) -> None:
     Raises:
         AssertionError: in case of problems
     """
-    if len(parameter_df.index) != len(set(parameter_df.index)):
+    non_unique_ids = get_non_unique(parameter_df.index)
+    if len(non_unique_ids) > 0:
         raise AssertionError(
-            f"{PARAMETER_ID} column in parameter table is not unique.")
+            f"Non-unique values found in the {PARAMETER_ID} column"
+            " of the parameter table: " + str(non_unique_ids))
 
 
 def assert_parameter_scale_is_valid(parameter_df: pd.DataFrame) -> None:
@@ -625,7 +628,7 @@ def assert_noise_distributions_valid(observable_df: pd.DataFrame) -> None:
                     f"table: {distr}.")
 
 
-def assert_observable_id_is_unique(observable_df: pd.DataFrame) -> None:
+def assert_unique_observable_ids(observable_df: pd.DataFrame) -> None:
     """
     Check if the observableId column of the observable table is unique.
 
@@ -635,9 +638,16 @@ def assert_observable_id_is_unique(observable_df: pd.DataFrame) -> None:
     Raises:
         AssertionError: in case of problems
     """
-    if len(observable_df.index) != len(set(observable_df.index)):
+    non_unique_ids = get_non_unique(observable_df.index)
+    if len(non_unique_ids) > 0:
         raise AssertionError(
-            f"{OBSERVABLE_ID} column in observable table is not unique.")
+            f"Non-unique values found in the {OBSERVABLE_ID} column"
+            " of the observable table: " + str(non_unique_ids))
+
+
+def get_non_unique(values):
+    counter = Counter(values)
+    return [value for (value, count) in counter.items() if count > 1]
 
 
 def lint_problem(problem: 'petab.Problem') -> bool:

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -417,3 +417,21 @@ def test_check_parameter_df():
     del parameter_df[NOMINAL_VALUE]
     with pytest.raises(AssertionError):
         lint.check_parameter_df(df=parameter_df)
+
+
+def test_check_observable_df():
+    """Check that we correctly detect errors in observable table"""
+
+    observable_df = pd.DataFrame(data={
+        OBSERVABLE_ID: ['obs1', 'obs2'],
+        OBSERVABLE_FORMULA: ['x1', 'x2'],
+        NOISE_FORMULA: ['sigma1', 'sigma2']
+    }).set_index(OBSERVABLE_ID)
+
+    lint.check_observable_df(observable_df)
+
+    # Check that duplicated observables ids are detected
+    bad_observable_df = observable_df.copy()
+    bad_observable_df.index = ['obs1', 'obs1']
+    with pytest.raises(AssertionError):
+        lint.check_observable_df(bad_observable_df)


### PR DESCRIPTION
The linter function `check_observable_df` does not detect duplicated observable IDs. MWE is
```python
import petab
import pandas as pd

observable_df = pd.DataFrame(data={
    petab.OBSERVABLE_ID: ['obs1', 'obs1'],
    petab.OBSERVABLE_FORMULA: ['x1', 'x2'],
    petab.NOISE_FORMULA: ['sigma1', 'sigma2']
}).set_index(petab.OBSERVABLE_ID)

petab.lint.check_observable_df(observable_df)
```
Incidentally, this causes a problem in `check_measurement_df` too.