### PR TITLE
Fix recursive docs build; Add pdf-doc script

### DIFF
--- a/doc/compile_doc.sh
+++ b/doc/compile_doc.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# Build a pdflatex document from the documentation
+
+# format A3
+pandoc documentation_data_format.rst -o documentation_data_format.pdf -V geometry:margin=1.5in -V geometry:a3paper -V fontsize=10pt --toc --pdf-engine pdflatex
+
+# format A2 landscape
+
+# pandoc documentation_data_format.rst -o documentation_data_format.pdf -V geometry:margin=.5in -V geometry:a4paper -V geometry:landscape -V fontsize=10pt --toc --pdf-engine pdflatex

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -49,7 +49,7 @@ templates_path = ['_templates']
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = []
+exclude_patterns = ['build/doctrees', 'build/html']
 
 master_doc = 'index'
 


### PR DESCRIPTION
Due to not ignoring the `build` sub-directory within the `doc` folder, repeated builds lead to recursively including all files under `build` in the new build (exponential growth). In my case 40MB -> 1GB after a few runs. Not a problem on readthedocs, where fresh virtual machines are used for each build.