### PR TITLE
Update PEtab support table for AMICI/pyPESTO/pyABC

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ different tools, based on passed test cases of the
 | 4  | Parametric observable parameter overrides in measurement table | +++                  | +--    | +++ | +++  | +++   | --+                   | +++   | +++                    | +++        |
 | 5  | Parametric overrides in condition table                        | +++                  | +--    | +++ | +++  | +++   | --+                   | +++   | +++                    | +++        |
 | 6  | Time-point specific overrides in the measurement table         | ---                  | ---    | +++ | +++  | +++   | ---                   | ---   | ---                    | +++        |
-| 7  | Observable transformations to log10 scale                      | +++                  | +--    | +++ | ++-  | +++   | --+                   | +-+   | +-+                    | +++        |
+| 7  | Observable transformations to log10 scale                      | +++                  | +--    | +++ | ++-  | +++   | --+                   | +++   | +++                    | +++        |
 | 8  | Replicate measurements                                         | +++                  | +--    | +++ | +++  | +++   | --+                   | +++   | +++                    | +++        |
 | 9  | Pre-equilibration                                              | +++                  | +--    | +++ | +++  | +++   | --+                   | +++   | +++                    | +++        |
 | 10 | Partial pre-equilibration                                      | +++                  | ---    | +++ | +++  | +++   | --+                   | +++   | +++                    | +++        |
@@ -93,7 +93,7 @@ different tools, based on passed test cases of the
 | 13 | Parametric initial concentrations in condition table           | +++                  | +--    | +++ | +++  | +++   | --+                   | +++   | +++                    | +++        |
 | 14 | Numeric noise parameter overrides in measurement table         | +++                  | +--    | +++ | +++  | +++   | --+                   | +++   | +++                    | +++        |
 | 15 | Parametric noise parameter overrides in measurement table      | +++                  | +--    | +++ | +++  | +++   | --+                   | +++   | +++                    | +++        |
-| 16 | Observable transformations to log scale                        | +++                  | +--    | +++ | ++-  | +++   | --+                   | +-+   | +-+                    | +++        |
+| 16 | Observable transformations to log scale                        | +++                  | +--    | +++ | ++-  | +++   | --+                   | +++   | +++                    | +++        |
 
 Legend:
 * First character indicates whether computing simulated data is supported and simulations are correct (+) or not (-).


### PR DESCRIPTION
With v0.11.19 AMICI supports observable transformations for residuals (https://github.com/AMICI-dev/AMICI/pull/1567).

This is also supported by pypesto and pyABC via AMICI.