### PR TITLE
Add `required` attribute to extensions in yaml file

### DIFF
--- a/doc/_static/petab_schema.yaml
+++ b/doc/_static/petab_schema.yaml
@@ -98,9 +98,14 @@ properties:
           version:
             type: string
             pattern: ^([1-9][0-9]*!)?(0|[1-9][0-9]*)(\.(0|[1-9][0-9]*))*((a|b|rc)(0|[1-9][0-9]*))?(\.post(0|[1-9][0-9]*))?(\.dev(0|[1-9][0-9]*))?$
-
+          required:
+            type: bool
+            description: |
+              Indicates whether the extension is required for the
+              mathematical interpretation of problem.
         required:
           - version
+          - required
       additionalProperties: true
 
     additionalProperties: false


### PR DESCRIPTION
PEtab extensions were introduced in #537. We should be able to distinguish there between optional extensions and required extensions, i.e. those that modify the parameter estimation problem as such, and those that just add additional/optional information (e.g. annotations, info for visualization, ...). If some tool does not know about a certain optional extension, it can safely be ignored during import, if it does not know about a required extension, it should fail.

This PR adds a `required` attribute to extensions in the yaml file to indicate whether they are required for the mathematical interpretation of the PEtab problem.

Resolves #544 