### PR TITLE
Add PEtab.jl to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,24 +89,24 @@ different tools, based on passed test cases of the
 [PEtab test suite](https://github.com/PEtab-dev/petab_test_suite):
 
 
-| ID | Test                                                           | AMICI<br>`>=0.11.19` | Copasi | D2D | dMod | MEIGO | parPE<br>`develop` | PEtab.jl <br>`>=1.1.0`  | pyABC<br>`>=0.10.1` | pyPESTO<br>`>=0.0.11` | SBML2Julia |
-|----|----------------------------------------------------------------|----------------------|--------|-----|-----|------|-------|-----------------------|-------|------------------------|------------|
-| 1  | Basic simulation                                               | +++                  | +++    | +++ | +++  | +++   | --+                   | +++ | +++   | +++                    | +++        |
-| 2  | Multiple simulation conditions                                 | +++                  | +++    | +++ | +++  | +++   | --+  | +++                 | +++   | +++                    | +++        |
-| 3  | Numeric observable parameter overrides in measurement table    | +++                  | +++    | +++ | +++  | +++   | --+   | +++                | +++   | +++                    | +++        |
-| 4  | Parametric observable parameter overrides in measurement table | +++                  | +++    | +++ | +++  | +++   | --+    | +++               | +++   | +++                    | +++        |
-| 5  | Parametric overrides in condition table                        | +++                  | +++    | +++ | +++  | +++   | --+    | +++               | +++   | +++                    | +++        |
-| 6  | Time-point specific overrides in the measurement table         | ---                  | ---    | +++ | +++  | +++   | ---      | +++             | ---   | ---                    | +++        |
-| 7  | Observable transformations to log10 scale                      | +++                  | +++    | +++ | ++-  | +++   | --+     | +++              | +++   | +++                    | +++        |
-| 8  | Replicate measurements                                         | +++                  | +++    | +++ | +++  | +++   | --+      | +++             | +++   | +++                    | +++        |
-| 9  | Pre-equilibration                                              | +++                  | ---    | +++ | +++  | +++   | --+   | +++                | +++   | +++                    | +++        |
-| 10 | Partial pre-equilibration                                      | +++                  | ---    | +++ | +++  | +++   | --+      | +++             | +++   | +++                    | +++        |
-| 11 | Numeric initial concentration in condition table               | +++                  | +++    | +++ | +++  | +++   | --+     | +++              | +++   | +++                    | +++        |
-| 12 | Numeric initial compartment sizes in condition table           | ---                  | +++    | +++ | +++  | +++   | ---                   | +++   | ---     | ---               | +++        |
-| 13 | Parametric initial concentrations in condition table           | +++                  | +++    | +++ | +++  | +++   | --+      | +++             | +++   | +++                    | +++        |
-| 14 | Numeric noise parameter overrides in measurement table         | +++                  | +++    | +++ | +++  | +++   | --+     | +++              | +++   | +++                    | +++        |
-| 15 | Parametric noise parameter overrides in measurement table      | +++                  | +++    | +++ | +++  | +++   | --+         | +++          | +++   | +++                    | +++        |
-| 16 | Observable transformations to log scale                        | +++                  | +++    | +++ | ++-  | +++   | --+      | +++             | +++   | +++                    | +++        |
+| ID | Test                                                           | AMICI<br>`>=0.11.19` | Copasi | D2D | dMod | MEIGO | parPE<br>`develop` | PEtab.jl <br>`>=1.1.0` | pyABC<br>`>=0.10.1` | pyPESTO<br>`>=0.0.11` | SBML2Julia |
+|----|----------------------------------------------------------------|----------------------|--------|-----|------|-------|--------------------|------------------------|---------------------|-----------------------|------------|
+| 1  | Basic simulation                                               | +++                  | +++    | +++ | +++  | +++   | --+                | +++                    | +++                 | +++                   | +++        |
+| 2  | Multiple simulation conditions                                 | +++                  | +++    | +++ | +++  | +++   | --+                | +++                    | +++                 | +++                   | +++        |
+| 3  | Numeric observable parameter overrides in measurement table    | +++                  | +++    | +++ | +++  | +++   | --+                | +++                    | +++                 | +++                   | +++        |
+| 4  | Parametric observable parameter overrides in measurement table | +++                  | +++    | +++ | +++  | +++   | --+                | +++                    | +++                 | +++                   | +++        |
+| 5  | Parametric overrides in condition table                        | +++                  | +++    | +++ | +++  | +++   | --+                | +++                    | +++                 | +++                   | +++        |
+| 6  | Time-point specific overrides in the measurement table         | ---                  | ---    | +++ | +++  | +++   | ---                | +++                    | ---                 | ---                   | +++        |
+| 7  | Observable transformations to log10 scale                      | +++                  | +++    | +++ | ++-  | +++   | --+                | +++                    | +++                 | +++                   | +++        |
+| 8  | Replicate measurements                                         | +++                  | +++    | +++ | +++  | +++   | --+                | +++                    | +++                 | +++                   | +++        |
+| 9  | Pre-equilibration                                              | +++                  | ---    | +++ | +++  | +++   | --+                | +++                    | +++                 | +++                   | +++        |
+| 10 | Partial pre-equilibration                                      | +++                  | ---    | +++ | +++  | +++   | --+                | +++                    | +++                 | +++                   | +++        |
+| 11 | Numeric initial concentration in condition table               | +++                  | +++    | +++ | +++  | +++   | --+                | +++                    | +++                 | +++                   | +++        |
+| 12 | Numeric initial compartment sizes in condition table           | ---                  | +++    | +++ | +++  | +++   | ---                | +++                    | ---                 | ---                   | +++        |
+| 13 | Parametric initial concentrations in condition table           | +++                  | +++    | +++ | +++  | +++   | --+                | +++                    | +++                 | +++                   | +++        |
+| 14 | Numeric noise parameter overrides in measurement table         | +++                  | +++    | +++ | +++  | +++   | --+                | +++                    | +++                 | +++                   | +++        |
+| 15 | Parametric noise parameter overrides in measurement table      | +++                  | +++    | +++ | +++  | +++   | --+                | +++                    | +++                 | +++                   | +++        |
+| 16 | Observable transformations to log scale                        | +++                  | +++    | +++ | ++-  | +++   | --+                | +++                    | +++                 | +++                   | +++        |
 
 Legend:
 * First character indicates whether computing simulated data is supported and simulations are correct (+) or not (-).

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Where PEtab is supported (in alphabetical order):
 
   - [parPE](https://github.com/ICB-DCM/parPE/)
 
-  - [PEtab.jl](https://github.com/sebapersson/PEtab.jl)
+  - [PEtab.jl](https://github.com/sebapersson/PEtab.jl) ([HOWTO](https://sebapersson.github.io/PEtab.jl/stable/))
 
   - [pyABC](https://github.com/ICB-DCM/pyABC/) ([Example](https://pyabc.readthedocs.io/en/latest/examples/petab.html))
 
@@ -89,24 +89,24 @@ different tools, based on passed test cases of the
 [PEtab test suite](https://github.com/PEtab-dev/petab_test_suite):
 
 
-| ID | Test                                                           | AMICI<br>`>=0.11.19` | Copasi | D2D | dMod | MEIGO | parPE<br>`develop`  | pyABC<br>`>=0.10.1` | pyPESTO<br>`>=0.0.11` | SBML2Julia |
-|----|----------------------------------------------------------------|----------------------|--------|-----|------|-------|-----------------------|-------|------------------------|------------|
-| 1  | Basic simulation                                               | +++                  | +++    | +++ | +++  | +++   | --+                   | +++   | +++                    | +++        |
-| 2  | Multiple simulation conditions                                 | +++                  | +++    | +++ | +++  | +++   | --+                   | +++   | +++                    | +++        |
-| 3  | Numeric observable parameter overrides in measurement table    | +++                  | +++    | +++ | +++  | +++   | --+                   | +++   | +++                    | +++        |
-| 4  | Parametric observable parameter overrides in measurement table | +++                  | +++    | +++ | +++  | +++   | --+                   | +++   | +++                    | +++        |
-| 5  | Parametric overrides in condition table                        | +++                  | +++    | +++ | +++  | +++   | --+                   | +++   | +++                    | +++        |
-| 6  | Time-point specific overrides in the measurement table         | ---                  | ---    | +++ | +++  | +++   | ---                   | ---   | ---                    | +++        |
-| 7  | Observable transformations to log10 scale                      | +++                  | +++    | +++ | ++-  | +++   | --+                   | +++   | +++                    | +++        |
-| 8  | Replicate measurements                                         | +++                  | +++    | +++ | +++  | +++   | --+                   | +++   | +++                    | +++        |
-| 9  | Pre-equilibration                                              | +++                  | ---    | +++ | +++  | +++   | --+                   | +++   | +++                    | +++        |
-| 10 | Partial pre-equilibration                                      | +++                  | ---    | +++ | +++  | +++   | --+                   | +++   | +++                    | +++        |
-| 11 | Numeric initial concentration in condition table               | +++                  | +++    | +++ | +++  | +++   | --+                   | +++   | +++                    | +++        |
-| 12 | Numeric initial compartment sizes in condition table           | ---                  | +++    | +++ | +++  | +++   | ---                   | ---   | ---                    | +++        |
-| 13 | Parametric initial concentrations in condition table           | +++                  | +++    | +++ | +++  | +++   | --+                   | +++   | +++                    | +++        |
-| 14 | Numeric noise parameter overrides in measurement table         | +++                  | +++    | +++ | +++  | +++   | --+                   | +++   | +++                    | +++        |
-| 15 | Parametric noise parameter overrides in measurement table      | +++                  | +++    | +++ | +++  | +++   | --+                   | +++   | +++                    | +++        |
-| 16 | Observable transformations to log scale                        | +++                  | +++    | +++ | ++-  | +++   | --+                   | +++   | +++                    | +++        |
+| ID | Test                                                           | AMICI<br>`>=0.11.19` | Copasi | D2D | dMod | MEIGO | parPE<br>`develop` | PEtab.jl <br>`>=1.1.0`  | pyABC<br>`>=0.10.1` | pyPESTO<br>`>=0.0.11` | SBML2Julia |
+|----|----------------------------------------------------------------|----------------------|--------|-----|-----|------|-------|-----------------------|-------|------------------------|------------|
+| 1  | Basic simulation                                               | +++                  | +++    | +++ | +++  | +++   | --+                   | +++ | +++   | +++                    | +++        |
+| 2  | Multiple simulation conditions                                 | +++                  | +++    | +++ | +++  | +++   | --+  | +++                 | +++   | +++                    | +++        |
+| 3  | Numeric observable parameter overrides in measurement table    | +++                  | +++    | +++ | +++  | +++   | --+   | +++                | +++   | +++                    | +++        |
+| 4  | Parametric observable parameter overrides in measurement table | +++                  | +++    | +++ | +++  | +++   | --+    | +++               | +++   | +++                    | +++        |
+| 5  | Parametric overrides in condition table                        | +++                  | +++    | +++ | +++  | +++   | --+    | +++               | +++   | +++                    | +++        |
+| 6  | Time-point specific overrides in the measurement table         | ---                  | ---    | +++ | +++  | +++   | ---      | +++             | ---   | ---                    | +++        |
+| 7  | Observable transformations to log10 scale                      | +++                  | +++    | +++ | ++-  | +++   | --+     | +++              | +++   | +++                    | +++        |
+| 8  | Replicate measurements                                         | +++                  | +++    | +++ | +++  | +++   | --+      | +++             | +++   | +++                    | +++        |
+| 9  | Pre-equilibration                                              | +++                  | ---    | +++ | +++  | +++   | --+   | +++                | +++   | +++                    | +++        |
+| 10 | Partial pre-equilibration                                      | +++                  | ---    | +++ | +++  | +++   | --+      | +++             | +++   | +++                    | +++        |
+| 11 | Numeric initial concentration in condition table               | +++                  | +++    | +++ | +++  | +++   | --+     | +++              | +++   | +++                    | +++        |
+| 12 | Numeric initial compartment sizes in condition table           | ---                  | +++    | +++ | +++  | +++   | ---                   | +++   | ---     | ---               | +++        |
+| 13 | Parametric initial concentrations in condition table           | +++                  | +++    | +++ | +++  | +++   | --+      | +++             | +++   | +++                    | +++        |
+| 14 | Numeric noise parameter overrides in measurement table         | +++                  | +++    | +++ | +++  | +++   | --+     | +++              | +++   | +++                    | +++        |
+| 15 | Parametric noise parameter overrides in measurement table      | +++                  | +++    | +++ | +++  | +++   | --+         | +++          | +++   | +++                    | +++        |
+| 16 | Observable transformations to log scale                        | +++                  | +++    | +++ | ++-  | +++   | --+      | +++             | +++   | +++                    | +++        |
 
 Legend:
 * First character indicates whether computing simulated data is supported and simulations are correct (+) or not (-).


### PR DESCRIPTION
PEtab.jl is now a formal Julia package. Starting from the latest release 1.1 we test against the [PEtab test suite](https://github.com/sebapersson/PEtab.jl/blob/main/test/PEtab_test_suite.jl), and I am happy to announce (with some tweaking from PEtab.jl v1.0 -> v1.1) that we pass all tests. I have added this information to the README.