### PR TITLE
Explicitly exclude SBML local parameters from parameters table

### DIFF
--- a/doc/documentation_data_format.rst
+++ b/doc/documentation_data_format.rst
@@ -443,6 +443,7 @@ and *must not* include:
   above)
 - Parameters included as column names in the *condition table*
 - Parameters that are AssignmentRule targets in the SBML model
+- SBML *local* parameters
 
 it *may* include:
 


### PR DESCRIPTION
Clarify that local parameters aren't allowed in the parameters table.

Closes #570