### PR TITLE
Move tool table to RTD

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,71 +49,9 @@ A wide range of PEtab examples can be found in the systems biology parameter est
 
 ## PEtab support in systems biology tools
 
-Where PEtab is supported (in alphabetical order):
+For a list of tools supporting PEtab, see the
+[PEtab website](https://petab.readthedocs.io/en/latest/software_support.html).
 
-
-  - [AMICI](https://github.com/ICB-DCM/AMICI/)
-    ([Example](https://github.com/ICB-DCM/AMICI/blob/master/python/examples/example_petab/petab.ipynb))
-
-  - A PEtab -> [COPASI](http://copasi.org/)
-    [converter](https://github.com/copasi/python-petab-importer)
-
-  - [d2d](https://github.com/Data2Dynamics/d2d/)
-    ([HOWTO](https://github.com/Data2Dynamics/d2d/wiki/Support-for-PEtab))
-
-  - [dMod](https://github.com/dkaschek/dMod/)
-    ([HOWTO](https://github.com/dkaschek/dMod/wiki/Support-for-PEtab))
-
-  - [MEIGO](https://github.com/gingproc-IIM-CSIC/MEIGO64)
-    ([HOWTO](https://github.com/gingproc-IIM-CSIC/MEIGO64/tree/master/MEIGO/PEtabMEIGO))
-
-  - [parPE](https://github.com/ICB-DCM/parPE/)
-
-  - [PEtab.jl](https://github.com/sebapersson/PEtab.jl) ([HOWTO](https://sebapersson.github.io/PEtab.jl/stable/))
-
-  - [PumasQSP.jl](https://help.juliahub.com/pumasqsp/stable/) ([HOWTO](https://help.juliahub.com/pumasqsp/stable/tutorials/petabimport/))
-
-  - [pyABC](https://github.com/ICB-DCM/pyABC/) ([Example](https://pyabc.readthedocs.io/en/latest/examples/petab.html))
-
-  - [pyPESTO](https://github.com/ICB-DCM/pyPESTO/)
-    ([Example](https://pypesto.readthedocs.io/en/latest/example/petab_import.html))
-
-  - [SBML2Julia](https://github.com/paulflang/SBML2Julia)
-    ([Tutorial](https://sbml2julia.readthedocs.io/en/latest/python_api.html))
-
-If your project or tool is using PEtab, and you would like to have it listed
-here, please [let us know](https://github.com/PEtab-dev/PEtab/issues).
-
-### PEtab features supported in different tools
-
-The following list provides an overview of supported PEtab features in
-different tools, based on passed test cases of the
-[PEtab test suite](https://github.com/PEtab-dev/petab_test_suite):
-
-
-| ID | Test                                                           | AMICI<br>`>=0.11.19` | Copasi | D2D | dMod | MEIGO | parPE<br>`develop` | PEtab.jl <br>`>=1.1.0` | PumasQSP | pyABC<br>`>=0.10.1` | pyPESTO<br>`>=0.0.11` | SBML2Julia |
-|----|----------------------------------------------------------------|----------------------|--------|-----|------|-------|--------------------|------------------------|----------|---------------------|-----------------------|------------|
-| 1  | Basic simulation                                               | +++                  | +++    | +++ | +++  | +++   | --+                | +++                    | +++      | +++                 | +++                   | +++        |
-| 2  | Multiple simulation conditions                                 | +++                  | +++    | +++ | +++  | +++   | --+                | +++                    | +++      | +++                 | +++                   | +++        |
-| 3  | Numeric observable parameter overrides in measurement table    | +++                  | +++    | +++ | +++  | +++   | --+                | +++                    | ---      | +++                 | +++                   | +++        |
-| 4  | Parametric observable parameter overrides in measurement table | +++                  | +++    | +++ | +++  | +++   | --+                | +++                    | +++      | +++                 | +++                   | +++        |
-| 5  | Parametric overrides in condition table                        | +++                  | +++    | +++ | +++  | +++   | --+                | +++                    | +++      | +++                 | +++                   | +++        |
-| 6  | Time-point specific overrides in the measurement table         | ---                  | ---    | +++ | +++  | +++   | ---                | +++                    | ---      | ---                 | ---                   | +++        |
-| 7  | Observable transformations to log10 scale                      | +++                  | +++    | +++ | ++-  | +++   | --+                | +++                    | +-+      | +++                 | +++                   | +++        |
-| 8  | Replicate measurements                                         | +++                  | +++    | +++ | +++  | +++   | --+                | +++                    | +++      | +++                 | +++                   | +++        |
-| 9  | Pre-equilibration                                              | +++                  | ---    | +++ | +++  | +++   | --+                | +++                    | ---      | +++                 | +++                   | +++        |
-| 10 | Partial pre-equilibration                                      | +++                  | ---    | +++ | +++  | +++   | --+                | +++                    | ---      | +++                 | +++                   | +++        |
-| 11 | Numeric initial concentration in condition table               | +++                  | +++    | +++ | +++  | +++   | --+                | +++                    | +++      | +++                 | +++                   | +++        |
-| 12 | Numeric initial compartment sizes in condition table           | ---                  | +++    | +++ | +++  | +++   | ---                | +++                    | ---      | ---                 | ---                   | +++        |
-| 13 | Parametric initial concentrations in condition table           | +++                  | +++    | +++ | +++  | +++   | --+                | +++                    | ---      | +++                 | +++                   | +++        |
-| 14 | Numeric noise parameter overrides in measurement table         | +++                  | +++    | +++ | +++  | +++   | --+                | +++                    | ---      | +++                 | +++                   | +++        |
-| 15 | Parametric noise parameter overrides in measurement table      | +++                  | +++    | +++ | +++  | +++   | --+                | +++                    | ---      | +++                 | +++                   | +++        |
-| 16 | Observable transformations to log scale                        | +++                  | +++    | +++ | ++-  | +++   | --+                | +++                    | ---      | +++                 | +++                   | +++        |
-
-Legend:
-* First character indicates whether computing simulated data is supported and simulations are correct (+) or not (-).
-* Second character indicates whether computing chi2 values of residuals are supported and correct (+) or not (-).
-* Third character indicates whether computing likelihoods is supported and correct (+) or not (-).
 
 ## Using PEtab
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -13,6 +13,7 @@
    :maxdepth: 2
    :caption: About
 
+   software_support
    Development <development>
    how_to_cite
    license

--- a/doc/software_support.rst
+++ b/doc/software_support.rst
@@ -1,0 +1,287 @@
+================
+Software support
+================
+
+Where PEtab is supported (in alphabetical order):
+
+* `AMICI <https://github.com/ICB-DCM/AMICI/>`__
+  (`Example <https://github.com/ICB-DCM/AMICI/blob/master/python/examples/example_petab/petab.ipynb>`__)
+
+* A PEtab -> `COPASI <http://copasi.org/>`__
+  `converter <https://github.com/copasi/python-petab-importer>`__
+
+* `d2d <https://github.com/Data2Dynamics/d2d/>`__
+  (`HOWTO <https://github.com/Data2Dynamics/d2d/wiki/Support-for-PEtab>`__)
+
+* `dMod <https://github.com/dkaschek/dMod/>`__
+  (`HOWTO <https://github.com/dkaschek/dMod/wiki/Support-for-PEtab>`__)
+
+* `MEIGO <https://github.com/gingproc-IIM-CSIC/MEIGO64>`__
+  (`HOWTO <https://github.com/gingproc-IIM-CSIC/MEIGO64/tree/master/MEIGO/PEtabMEIGO>`__)
+
+* `parPE <https://github.com/ICB-DCM/parPE/>`__
+
+* `PEtab.jl <https://github.com/sebapersson/PEtab.jl>`__
+  (`HOWTO <https://sebapersson.github.io/PEtab.jl/stable/>`__)
+
+* `PumasQSP.jl <https://help.juliahub.com/pumasqsp/stable/>`__
+  (`HOWTO <https://help.juliahub.com/pumasqsp/stable/tutorials/petabimport/>`__)
+
+* `pyABC <https://github.com/ICB-DCM/pyABC/>`__
+  (`Example <https://pyabc.readthedocs.io/en/latest/examples/petab.html>`__)
+
+* `pyPESTO <https://github.com/ICB-DCM/pyPESTO/>`__
+  (`Example <https://pypesto.readthedocs.io/en/latest/example/petab_import.html>`__)
+
+* `SBML2Julia <https://github.com/paulflang/SBML2Julia>`__
+  (`Tutorial <https://sbml2julia.readthedocs.io/en/latest/python_api.html>`__)
+
+If your project or tool is using PEtab, and you would like to have it listed
+here, please `let us know <https://github.com/PEtab-dev/PEtab/issues>`__.
+
+PEtab features supported in different tools
+===========================================
+
+The following table provides an overview of supported PEtab features in
+different tools, based on passed test cases of the
+`PEtab test suite <https://github.com/PEtab-dev/petab_test_suite>`__:
+
+..
+   START TABLE Tool support (GENERATED, DO NOT EDIT, INSTEAD EDIT IN PEtab/doc/src)
+.. list-table:: Tool support
+   :header-rows: 1
+
+   * - | ID
+     - | Test
+     - | AMICI;`>=0.11.19`
+     - | Copasi
+     - | D2D
+     - | dMod
+     - | MEIGO
+     - | parPE;`develop`
+     - | PEtab.jl;`>=1.1.0`
+     - | PumasQSP
+     - | pyABC;`>=0.10.1`
+     - | pyPESTO;`>=0.0.11`
+     - | SBML2Julia
+   * - 1
+     - Basic simulation
+     - +++
+     - +++
+     - +++
+     - +++
+     - +++
+     - --+
+     - +++
+     - +++
+     - +++
+     - +++
+     - +++
+   * - 2
+     - Multiple simulation conditions
+     - +++
+     - +++
+     - +++
+     - +++
+     - +++
+     - --+
+     - +++
+     - +++
+     - +++
+     - +++
+     - +++
+   * - 3
+     - Numeric observable parameter overrides in measurement table
+     - +++
+     - +++
+     - +++
+     - +++
+     - +++
+     - --+
+     - +++
+     - ---
+     - +++
+     - +++
+     - +++
+   * - 4
+     - Parametric observable parameter overrides in measurement table
+     - +++
+     - +++
+     - +++
+     - +++
+     - +++
+     - --+
+     - +++
+     - +++
+     - +++
+     - +++
+     - +++
+   * - 5
+     - Parametric overrides in condition table
+     - +++
+     - +++
+     - +++
+     - +++
+     - +++
+     - --+
+     - +++
+     - +++
+     - +++
+     - +++
+     - +++
+   * - 6
+     - Time-point specific overrides in the measurement table
+     - ---
+     - ---
+     - +++
+     - +++
+     - +++
+     - ---
+     - +++
+     - ---
+     - ---
+     - ---
+     - +++
+   * - 7
+     - Observable transformations to log10 scale
+     - +++
+     - +++
+     - +++
+     - ++-
+     - +++
+     - --+
+     - +++
+     - +-+
+     - +++
+     - +++
+     - +++
+   * - 8
+     - Replicate measurements
+     - +++
+     - +++
+     - +++
+     - +++
+     - +++
+     - --+
+     - +++
+     - +++
+     - +++
+     - +++
+     - +++
+   * - 9
+     - Pre-equilibration
+     - +++
+     - ---
+     - +++
+     - +++
+     - +++
+     - --+
+     - +++
+     - ---
+     - +++
+     - +++
+     - +++
+   * - 10
+     - Partial pre-equilibration
+     - +++
+     - ---
+     - +++
+     - +++
+     - +++
+     - --+
+     - +++
+     - ---
+     - +++
+     - +++
+     - +++
+   * - 11
+     - Numeric initial concentration in condition table
+     - +++
+     - +++
+     - +++
+     - +++
+     - +++
+     - --+
+     - +++
+     - +++
+     - +++
+     - +++
+     - +++
+   * - 12
+     - Numeric initial compartment sizes in condition table
+     - ---
+     - +++
+     - +++
+     - +++
+     - +++
+     - ---
+     - +++
+     - ---
+     - ---
+     - ---
+     - +++
+   * - 13
+     - Parametric initial concentrations in condition table
+     - +++
+     - +++
+     - +++
+     - +++
+     - +++
+     - --+
+     - +++
+     - ---
+     - +++
+     - +++
+     - +++
+   * - 14
+     - Numeric noise parameter overrides in measurement table
+     - +++
+     - +++
+     - +++
+     - +++
+     - +++
+     - --+
+     - +++
+     - ---
+     - +++
+     - +++
+     - +++
+   * - 15
+     - Parametric noise parameter overrides in measurement table
+     - +++
+     - +++
+     - +++
+     - +++
+     - +++
+     - --+
+     - +++
+     - ---
+     - +++
+     - +++
+     - +++
+   * - 16
+     - Observable transformations to log scale
+     - +++
+     - +++
+     - +++
+     - ++-
+     - +++
+     - --+
+     - +++
+     - ---
+     - +++
+     - +++
+     - +++
+
+..
+   END TABLE Tool support
+
+
+Legend:
+
+* First character indicates whether computing simulated data is supported
+  and simulations are correct (+) or not (-).
+* Second character indicates whether computing chi2 values
+  of residuals are supported and correct (+) or not (-).
+* Third character indicates whether computing likelihoods is supported
+  and correct (+) or not (-).

--- a/doc/src/Supported functions.tsv
+++ b/doc/src/Supported functions.tsv
@@ -9,5 +9,5 @@ Function	Comment	Argument types	Evaluates to
 ``arcsinh``;``arccosh``;``arctanh``;``arccoth``;``arcsech``;``arccsch``	inverse hyperbolic functions	float	float
 ``piecewise(``;    ``true_value_1,``;      ``condition_1,``;    ``[true_value_2,``;      ``condition_2,]``;    ``[...]``;    ``[true_value_n,``;      ``condition_n,]``;    ``otherwise``;``)``	The function value is;the ``true_value*`` for the;first ``true`` ``condition*``;or ``otherwise`` if all;conditions are ``false``.	``*value*``: all float or all bool;``condition*``: all bool	float
 ``abs(x)``	absolute value;``piecewise(x, x>=0, -x)``	float	float
-``sign(x)``	sign of ``x``;``piecewise(1, x>=0, -1)``	float	float
+``sign(x)``	sign of ``x``;``piecewise(1, x > 0, -1, x < 0, 0)``	float	float
 ``min(a, b)``;``max(a, b)``	minimum / maximum of {``a``, ``b``};``piecewise(a, a<=b, b)``;``piecewise(a, a>=b, b)``	float, float	float

--- a/doc/src/Tool support.tsv
+++ b/doc/src/Tool support.tsv
@@ -1,0 +1,17 @@
+ID	Test	"AMICI;`>=0.11.19`"	Copasi	D2D	dMod	MEIGO	"parPE;`develop`"	"PEtab.jl;`>=1.1.0`"	PumasQSP	"pyABC;`>=0.10.1`"	"pyPESTO;`>=0.0.11`"	SBML2Julia
+1	Basic simulation	+++	+++	+++	+++	+++	--+	+++	+++	+++	+++	+++
+2	Multiple simulation conditions	+++	+++	+++	+++	+++	--+	+++	+++	+++	+++	+++
+3	Numeric observable parameter overrides in measurement table	+++	+++	+++	+++	+++	--+	+++	---	+++	+++	+++
+4	Parametric observable parameter overrides in measurement table	+++	+++	+++	+++	+++	--+	+++	+++	+++	+++	+++
+5	Parametric overrides in condition table	+++	+++	+++	+++	+++	--+	+++	+++	+++	+++	+++
+6	Time-point specific overrides in the measurement table	---	---	+++	+++	+++	---	+++	---	---	---	+++
+7	Observable transformations to log10 scale	+++	+++	+++	++-	+++	--+	+++	+-+	+++	+++	+++
+8	Replicate measurements	+++	+++	+++	+++	+++	--+	+++	+++	+++	+++	+++
+9	Pre-equilibration	+++	---	+++	+++	+++	--+	+++	---	+++	+++	+++
+10	Partial pre-equilibration	+++	---	+++	+++	+++	--+	+++	---	+++	+++	+++
+11	Numeric initial concentration in condition table	+++	+++	+++	+++	+++	--+	+++	+++	+++	+++	+++
+12	Numeric initial compartment sizes in condition table	---	+++	+++	+++	+++	---	+++	---	---	---	+++
+13	Parametric initial concentrations in condition table	+++	+++	+++	+++	+++	--+	+++	---	+++	+++	+++
+14	Numeric noise parameter overrides in measurement table	+++	+++	+++	+++	+++	--+	+++	---	+++	+++	+++
+15	Parametric noise parameter overrides in measurement table	+++	+++	+++	+++	+++	--+	+++	---	+++	+++	+++
+16	Observable transformations to log scale	+++	+++	+++	++-	+++	--+	+++	---	+++	+++	+++

--- a/doc/src/update_tables.py
+++ b/doc/src/update_tables.py
@@ -9,10 +9,16 @@ table_dir = Path(__file__).parent
 MULTILINE_DELIMITER = ";"
 tables = {
     "Supported functions": {
-        "target": doc_dir / "documentation_data_format.rst",
+        "target": doc_dir / "v2" / "documentation_data_format.rst",
         "options": {
             "header-rows": "1",
             # "widths": "20 10 10 5",
+        },
+    },
+    "Tool support": {
+        "target": doc_dir / "software_support.rst",
+        "options": {
+            "header-rows": "1",
         },
     },
 }
@@ -83,7 +89,7 @@ DISCLAIMER = "(GENERATED, DO NOT EDIT, INSTEAD EDIT IN PEtab/doc/src)"
 for table_id, table_data in tables.items():
     target_file = table_data["target"]
     options = table_data["options"]
-    df = pd.read_csv(table_dir/ f"{table_id}.tsv", sep="\t")
+    df = pd.read_csv(table_dir/ f"{table_id}.tsv", sep="\t", dtype=str)
     table = df_to_list_table(df, options=options, name=table_id)
     replace_text(
         filename=target_file,


### PR DESCRIPTION
Move the tool support table from the repository README to a separate page of the ReadTheDocs documentation to make the README less crowded. Convert to more maintainable format (auto-generate RST table from TSV).

:eyes: https://petab--601.org.readthedocs.build/en/601/software_support.html