### PR TITLE
v2: Change `parameter_file` to `parameter_files`

### DIFF
--- a/doc/v2/_static/petab_schema_v2.yaml
+++ b/doc/v2/_static/petab_schema_v2.yaml
@@ -14,14 +14,15 @@ properties:
 
     description: Version of the PEtab format
 
-  parameter_file:
-    oneOf:
-    - type: string
-    - type: array
+  parameter_files:
+    type: array
     description: |
-      File name (absolute or relative) or URL to PEtab parameter table
-      containing parameters of all models listed in `problems`. A single
-      table may be split into multiple files and described as an array here.
+      List of PEtab parameter files.
+
+    items:
+        type: string
+        description: |
+          File name (absolute or relative) or URL to a PEtab parameter table.
 
   model_files:
     type: object


### PR DESCRIPTION
In the PEtab v2 yaml schema, let's change `parameter_file` to `parameter_files` and always require a list for consistency with how other tables are handled.