### PR TITLE
Add `id` field

### DIFF
--- a/doc/v2/_static/petab_schema_v2.yaml
+++ b/doc/v2/_static/petab_schema_v2.yaml
@@ -14,6 +14,11 @@ properties:
 
     description: Version of the PEtab format
 
+  id:
+    type: string
+    description: Identifier of the PEtab problem.
+    pattern: "^[a-zA-Z_]\\w*$"
+
   parameter_files:
     type: array
     description: |

--- a/doc/v2/_static/petab_schema_v2.yaml
+++ b/doc/v2/_static/petab_schema_v2.yaml
@@ -16,7 +16,10 @@ properties:
 
   id:
     type: string
-    description: Identifier of the PEtab problem.
+    description: |
+      Identifier of the PEtab problem.
+
+      This is optional and has no effect on the PEtab problem itself.
     pattern: "^[a-zA-Z_]\\w*$"
 
   parameter_files:


### PR DESCRIPTION
I think it would often be convenient to have some ID for a given PEtab problem and I would like to add such a field to the yaml schema. Previously, we usually used the model ID in such situations. However, often we have multiple problems based on the same model but different datasets, and this doesn't work well in the case of multiple models.

Not sure whether it should be mandatory or optional. I think, I'd go for optional.