### PR TITLE
doc: m2r2->myst

### DIFF
--- a/.rtd_pip_reqs.txt
+++ b/.rtd_pip_reqs.txt
@@ -4,7 +4,7 @@
 # sphinx-reredirects
 # sphinx-rtd-theme
 # sphinxcontrib-napoleon
-# m2r2
+# myst-parser
 alabaster==1.0.0
 babel==2.17.0
 certifi==2025.7.9
@@ -17,7 +17,6 @@ idna==3.10
 imagesize==1.4.1
 Jinja2==3.1.6
 kiwisolver==1.4.8
-m2r2==0.3.4
 Markdown==3.8.2
 MarkupSafe==3.0.2
 matplotlib==3.10.3
@@ -51,3 +50,8 @@ sphinxcontrib-serializinghtml==2.0.0
 tzdata==2025.2
 urllib3==2.5.0
 wheel==0.45.1
+markdown-it-py==3.0.0
+mdit-py-plugins==0.5.0
+mdurl==0.1.2
+myst-parser==4.0.1
+pyyaml==6.0.2

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -37,7 +37,7 @@ subprocess.run(['python', 'md2rst.py'])
 extensions = [
     'sphinx.ext.napoleon',
     'sphinx.ext.autodoc',
-    'm2r2',
+    'myst_parser',
     'sphinx.ext.autosummary',
     'sphinx_markdown_tables',
     'sphinx_reredirects',


### PR DESCRIPTION
Use `myst-parser` instead of `m2r2`.

Fixes the following warning when building docs:
```
lib/python3.13/site-packages/m2r2.py:20: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
  from pkg_resources import get_distribution
```