### PR TITLE
Clarify prior & bounds

### DIFF
--- a/doc/v2/documentation_data_format.rst
+++ b/doc/v2/documentation_data_format.rst
@@ -922,10 +922,10 @@ are listed below. PEtab only supports univariate prior distributions.
 The probability density functions (PDFs) below assume that the parameter bounds
 are wide enough to not truncate the distributions. If the parameter bounds
 are narrower than the distribution's support, the distributions are truncated,
-resulting in the following effective prior distribution:
+resulting in the following truncated prior distribution:
 
 .. math::
-   \pi_{\text{eff}}(x) = \frac{\pi(x)}{\text{CDF}(\text{upperBound}) - \text{CDF}(\text{lowerBound})}
+   \pi_{\text{trunc}}(x) = \frac{\pi(x)}{\text{CDF}(\text{upperBound}) - \text{CDF}(\text{lowerBound})}
 
 where :math:`\pi(x)` is the PDF of the non-truncated distribution
 and :math:`\text{CDF}(\cdot)` its cumulative distribution function.


### PR DESCRIPTION
Make the parameter prior description more consistent and explicit.

Previously, it said that parameter bounds truncate the prior distributions, but the provided PDFs suggested otherwise.

:eyes: https://petab--655.org.readthedocs.build/en/655/v2/documentation_data_format.html#prior-distributions